### PR TITLE
Feature/13 숙박 예약 신청 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ out/
 
 ### VS Code ###
 .vscode/
+src/main/generated

--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,9 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+    // Rest Assured
+    testImplementation 'io.rest-assured:rest-assured:5.3.2'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,10 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
+    // JPA Json
+    implementation 'io.hypersistence:hypersistence-utils-hibernate-62:3.6.1'
+    implementation 'com.fasterxml.jackson.module:jackson-module-jakarta-xmlbind-annotations'
+
     // Spring REST Docs
     asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -68,3 +68,10 @@ The response body will include an error providing further information
 | The request could not be completed due to a conflict with the current state of the target resource.
 This code is used in situations where the user might be able to resolve the conflict and resubmit the request.
 |===
+
+[[overview_http_verbs]]
+== Order
+
+숙박 예약 기능
+
+include::order.adoc[]

--- a/src/docs/asciidoc/order.adoc
+++ b/src/docs/asciidoc/order.adoc
@@ -1,0 +1,14 @@
+== 숙박 예약 신청
+
+include::{snippets}/order/registerOrder/success/request-fields.adoc[]
+
+==== HTTP request
+include::{snippets}/order/registerOrder/success/http-request.adoc[]
+
+==== HTTP response fields
+
+include::{snippets}/order/registerOrder/success/response-fields.adoc[]
+
+==== HTTP request
+
+include::{snippets}/order/registerOrder/success/http-response.adoc[]

--- a/src/main/java/com/fastcampus/reserve/application/order/OrderFacade.java
+++ b/src/main/java/com/fastcampus/reserve/application/order/OrderFacade.java
@@ -1,0 +1,19 @@
+package com.fastcampus.reserve.application.order;
+
+import com.fastcampus.reserve.domain.order.OrderService;
+import com.fastcampus.reserve.domain.order.dto.request.RegisterOrderDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class OrderFacade {
+
+    private final OrderService orderService;
+
+    public String registerOrder(RegisterOrderDto dto) {
+        return orderService.registerOrder(dto);
+    }
+}

--- a/src/main/java/com/fastcampus/reserve/common/config/ObjectMapperConfig.java
+++ b/src/main/java/com/fastcampus/reserve/common/config/ObjectMapperConfig.java
@@ -1,0 +1,21 @@
+package com.fastcampus.reserve.common.config;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ObjectMapperConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        return objectMapper;
+    }
+}

--- a/src/main/java/com/fastcampus/reserve/common/config/RedisConfig.java
+++ b/src/main/java/com/fastcampus/reserve/common/config/RedisConfig.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
 
 @Configuration
 public class RedisConfig {
@@ -18,5 +19,12 @@ public class RedisConfig {
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
         return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<?, ?> redisTemplate() {
+        RedisTemplate<byte[], byte[]> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        return redisTemplate;
     }
 }

--- a/src/main/java/com/fastcampus/reserve/common/config/RedisConfig.java
+++ b/src/main/java/com/fastcampus/reserve/common/config/RedisConfig.java
@@ -1,0 +1,22 @@
+package com.fastcampus.reserve.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${redis.host}")
+    private String host;
+
+    @Value("${redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+}

--- a/src/main/java/com/fastcampus/reserve/common/response/ErrorCode.java
+++ b/src/main/java/com/fastcampus/reserve/common/response/ErrorCode.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ErrorCode {
 
+    COMMON_SYSTEM_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "시스템 오류입니다."),
     COMMON_INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
 
     INVALID_USER_ROLE(HttpStatus.INTERNAL_SERVER_ERROR, "잘못된 사용자 역할입니다."),

--- a/src/main/java/com/fastcampus/reserve/common/response/ErrorCode.java
+++ b/src/main/java/com/fastcampus/reserve/common/response/ErrorCode.java
@@ -8,6 +8,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ErrorCode {
 
+    COMMON_INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+
     INVALID_USER_ROLE(HttpStatus.INTERNAL_SERVER_ERROR, "잘못된 사용자 역할입니다."),
     NOT_AUTHORITY_TOKEN(HttpStatus.UNAUTHORIZED, "권한이 없는 토큰 정보입니다.")
     ;

--- a/src/main/java/com/fastcampus/reserve/common/security/config/SecurityConfig.java
+++ b/src/main/java/com/fastcampus/reserve/common/security/config/SecurityConfig.java
@@ -15,6 +15,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 @Configuration
 @EnableWebSecurity
@@ -39,6 +40,7 @@ public class SecurityConfig {
 
         http
             .authorizeHttpRequests(authorize -> authorize
+                .requestMatchers(new AntPathRequestMatcher("/v1/orders")).permitAll()
                 .requestMatchers(PathRequest.toH2Console()).permitAll()
                 .anyRequest().authenticated())
         ;

--- a/src/main/java/com/fastcampus/reserve/common/utils/ValidateUtils.java
+++ b/src/main/java/com/fastcampus/reserve/common/utils/ValidateUtils.java
@@ -1,7 +1,8 @@
 package com.fastcampus.reserve.common.utils;
 
+import static com.fastcampus.reserve.common.response.ErrorCode.COMMON_INVALID_PARAMETER;
+
 import com.fastcampus.reserve.common.exception.CustomException;
-import com.fastcampus.reserve.common.response.ErrorCode;
 import java.util.List;
 import java.util.Objects;
 
@@ -10,15 +11,17 @@ public final class ValidateUtils {
     private ValidateUtils() {
     }
 
-    public static void nullCheck(Object param) {
-        if (Objects.isNull(param)) {
-            throw new CustomException(ErrorCode.COMMON_INVALID_PARAMETER);
+    public static void nullCheck(Object... params) {
+        for (Object param : params) {
+            if (Objects.isNull(param)) {
+                throw new CustomException(COMMON_INVALID_PARAMETER);
+            }
         }
     }
 
     public static void emptyCheck(List<?> param) {
         if (param.isEmpty()) {
-            throw new CustomException(ErrorCode.COMMON_INVALID_PARAMETER);
+            throw new CustomException(COMMON_INVALID_PARAMETER);
         }
     }
 }

--- a/src/main/java/com/fastcampus/reserve/common/utils/ValidateUtils.java
+++ b/src/main/java/com/fastcampus/reserve/common/utils/ValidateUtils.java
@@ -1,0 +1,24 @@
+package com.fastcampus.reserve.common.utils;
+
+import com.fastcampus.reserve.common.exception.CustomException;
+import com.fastcampus.reserve.common.response.ErrorCode;
+import java.util.List;
+import java.util.Objects;
+
+public final class ValidateUtils {
+
+    private ValidateUtils() {
+    }
+
+    public static void nullCheck(Object param) {
+        if (Objects.isNull(param)) {
+            throw new CustomException(ErrorCode.COMMON_INVALID_PARAMETER);
+        }
+    }
+
+    public static void emptyCheck(List<?> param) {
+        if(param.isEmpty()) {
+            throw new CustomException(ErrorCode.COMMON_INVALID_PARAMETER);
+        }
+    }
+}

--- a/src/main/java/com/fastcampus/reserve/common/utils/ValidateUtils.java
+++ b/src/main/java/com/fastcampus/reserve/common/utils/ValidateUtils.java
@@ -17,7 +17,7 @@ public final class ValidateUtils {
     }
 
     public static void emptyCheck(List<?> param) {
-        if(param.isEmpty()) {
+        if (param.isEmpty()) {
             throw new CustomException(ErrorCode.COMMON_INVALID_PARAMETER);
         }
     }

--- a/src/main/java/com/fastcampus/reserve/domain/RedisService.java
+++ b/src/main/java/com/fastcampus/reserve/domain/RedisService.java
@@ -1,0 +1,14 @@
+package com.fastcampus.reserve.domain;
+
+import java.util.Optional;
+
+public interface RedisService {
+
+    <T> Optional<T> get(String key, Class<T> type);
+
+    void set(String key, Object value, Long expiredTime);
+
+    boolean setIfAbsent(String key, Object value, Long expiredTime);
+
+    boolean delete(String key);
+}

--- a/src/main/java/com/fastcampus/reserve/domain/order/Order.java
+++ b/src/main/java/com/fastcampus/reserve/domain/order/Order.java
@@ -5,8 +5,6 @@ import com.fastcampus.reserve.domain.order.orderitem.OrderItem;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -34,9 +32,6 @@ public class Order extends BaseTimeEntity {
     @Column(nullable = false)
     private Long userId;
 
-    @Enumerated(EnumType.STRING)
-    private StatusType status;
-
     @Column(length = 100)
     private String userName;
 
@@ -52,33 +47,16 @@ public class Order extends BaseTimeEntity {
     @Builder
     private Order(
             Long userId,
-            StatusType statusType,
             String userName,
             String userPhone
     ) {
         this.userId = userId;
-        this.status = statusType;
         this.userName = userName;
         this.userPhone = userPhone;
     }
 
     public void addOrderItem(OrderItem orderItem) {
         orderItems.add(orderItem);
-    }
-
-    public Order init(Long userId) {
-        return Order.builder()
-                .userId(userId)
-                .statusType(StatusType.INIT)
-                .build();
-    }
-
-    public void payment(
-            String userName,
-            String userPhone
-    ) {
-        this.userName = userName;
-        this.userPhone = userPhone;
     }
 
     @Getter

--- a/src/main/java/com/fastcampus/reserve/domain/order/OrderService.java
+++ b/src/main/java/com/fastcampus/reserve/domain/order/OrderService.java
@@ -1,0 +1,27 @@
+package com.fastcampus.reserve.domain.order;
+
+import com.fastcampus.reserve.domain.RedisService;
+import com.fastcampus.reserve.domain.order.dto.request.RegisterOrderDto;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class OrderService {
+
+    private static final long INIT_ORDER_EXPIRED_TIME = 3600L;
+
+    private final RedisService redisService;
+
+    public String registerOrder(RegisterOrderDto dto) {
+        var registerOrder = dto.toEntity();
+        var key = UUID.randomUUID().toString();
+        redisService.set(key, registerOrder, INIT_ORDER_EXPIRED_TIME);
+        return key;
+    }
+}

--- a/src/main/java/com/fastcampus/reserve/domain/order/RegisterOrder.java
+++ b/src/main/java/com/fastcampus/reserve/domain/order/RegisterOrder.java
@@ -1,0 +1,18 @@
+package com.fastcampus.reserve.domain.order;
+
+import static com.fastcampus.reserve.common.utils.ValidateUtils.emptyCheck;
+
+import com.fastcampus.reserve.domain.order.orderitem.OrderItem;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record RegisterOrder(
+        Long userId,
+        List<OrderItem> orderItems
+) {
+
+    public RegisterOrder {
+        emptyCheck(orderItems);
+    }
+}

--- a/src/main/java/com/fastcampus/reserve/domain/order/dto/request/RegisterOrderDto.java
+++ b/src/main/java/com/fastcampus/reserve/domain/order/dto/request/RegisterOrderDto.java
@@ -1,0 +1,30 @@
+package com.fastcampus.reserve.domain.order.dto.request;
+
+import static com.fastcampus.reserve.common.utils.ValidateUtils.emptyCheck;
+
+import com.fastcampus.reserve.domain.order.RegisterOrder;
+import com.fastcampus.reserve.domain.order.orderitem.OrderItem;
+import java.util.List;
+
+public record RegisterOrderDto(
+        Long userId,
+        List<RegisterOrderItemDto> registerOrderItems
+) {
+
+    public RegisterOrderDto {
+        emptyCheck(registerOrderItems);
+    }
+
+    public RegisterOrder toEntity() {
+        return RegisterOrder.builder()
+                .userId(userId)
+                .orderItems(getOrderItems())
+                .build();
+    }
+
+    private List<OrderItem> getOrderItems() {
+        return registerOrderItems.stream()
+                .map(RegisterOrderItemDto::toEntity)
+                .toList();
+    }
+}

--- a/src/main/java/com/fastcampus/reserve/domain/order/dto/request/RegisterOrderItemDto.java
+++ b/src/main/java/com/fastcampus/reserve/domain/order/dto/request/RegisterOrderItemDto.java
@@ -18,14 +18,16 @@ public record RegisterOrderItemDto(
 ) {
 
     public RegisterOrderItemDto {
-        nullCheck(productId);
-        nullCheck(roomId);
-        nullCheck(checkInDate);
-        nullCheck(checkInTime);
-        nullCheck(checkOutDate);
-        nullCheck(checkOutTime);
-        nullCheck(guestCount);
-        nullCheck(price);
+        nullCheck(
+                productId,
+                roomId,
+                checkInDate,
+                checkInTime,
+                checkOutDate,
+                checkOutTime,
+                guestCount,
+                price
+        );
     }
 
     public OrderItem toEntity() {

--- a/src/main/java/com/fastcampus/reserve/domain/order/dto/request/RegisterOrderItemDto.java
+++ b/src/main/java/com/fastcampus/reserve/domain/order/dto/request/RegisterOrderItemDto.java
@@ -1,0 +1,43 @@
+package com.fastcampus.reserve.domain.order.dto.request;
+
+import static com.fastcampus.reserve.common.utils.ValidateUtils.nullCheck;
+
+import com.fastcampus.reserve.domain.order.orderitem.OrderItem;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record RegisterOrderItemDto(
+        Long productId,
+        Long roomId,
+        LocalDate checkInDate,
+        LocalTime checkInTime,
+        LocalDate checkOutDate,
+        LocalTime checkOutTime,
+        Integer guestCount,
+        Integer price
+) {
+
+    public RegisterOrderItemDto {
+        nullCheck(productId);
+        nullCheck(roomId);
+        nullCheck(checkInDate);
+        nullCheck(checkInTime);
+        nullCheck(checkOutDate);
+        nullCheck(checkOutTime);
+        nullCheck(guestCount);
+        nullCheck(price);
+    }
+
+    public OrderItem toEntity() {
+        return OrderItem.builder()
+                .productId(productId)
+                .roomId(roomId)
+                .checkInDate(checkInDate)
+                .checkInTime(checkInTime)
+                .checkOutDate(checkOutDate)
+                .checkOutTime(checkOutTime)
+                .guestCount(guestCount)
+                .price(price)
+                .build();
+    }
+}

--- a/src/main/java/com/fastcampus/reserve/domain/order/orderitem/OrderItem.java
+++ b/src/main/java/com/fastcampus/reserve/domain/order/orderitem/OrderItem.java
@@ -10,6 +10,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -44,7 +45,7 @@ public class OrderItem extends BaseTimeEntity {
     private Order order;
 
     @Builder
-    public OrderItem(
+    private OrderItem(
             Long productId,
             Long roomId,
             Integer guestCount,
@@ -58,6 +59,15 @@ public class OrderItem extends BaseTimeEntity {
         this.price = price;
         this.visit = visitType;
         this.cartId = cartId;
+    }
+
+    public void registerOrder(Order order) {
+        if (!Objects.isNull(this.order)) {
+            this.order.getOrderItems().remove(this);
+        }
+
+        this.order = order;
+        order.addOrderItem(this);
     }
 
     public enum VisitType {

--- a/src/main/java/com/fastcampus/reserve/domain/order/orderitem/OrderItem.java
+++ b/src/main/java/com/fastcampus/reserve/domain/order/orderitem/OrderItem.java
@@ -10,6 +10,8 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -37,8 +39,11 @@ public class OrderItem extends BaseTimeEntity {
     @Column(nullable = false)
     private Integer price;
 
-    private VisitType visit;
     private Long cartId;
+    private LocalDate checkInDate;
+    private LocalTime checkInTime;
+    private LocalDate checkOutDate;
+    private LocalTime checkOutTime;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "order_id")
@@ -50,15 +55,21 @@ public class OrderItem extends BaseTimeEntity {
             Long roomId,
             Integer guestCount,
             Integer price,
-            VisitType visitType,
-            Long cartId
+            Long cartId,
+            LocalDate checkInDate,
+            LocalTime checkInTime,
+            LocalDate checkOutDate,
+            LocalTime checkOutTime
     ) {
         this.productId = productId;
         this.roomId = roomId;
         this.guestCount = guestCount;
         this.price = price;
-        this.visit = visitType;
         this.cartId = cartId;
+        this.checkInDate = checkInDate;
+        this.checkInTime = checkInTime;
+        this.checkOutDate = checkOutDate;
+        this.checkOutTime = checkOutTime;
     }
 
     public void registerOrder(Order order) {
@@ -68,9 +79,5 @@ public class OrderItem extends BaseTimeEntity {
 
         this.order = order;
         order.addOrderItem(this);
-    }
-
-    public enum VisitType {
-        WALK, CAR
     }
 }

--- a/src/main/java/com/fastcampus/reserve/domain/order/payment/Payment.java
+++ b/src/main/java/com/fastcampus/reserve/domain/order/payment/Payment.java
@@ -7,6 +7,7 @@ import java.util.Arrays;
 public enum Payment {
 
     CARD,
+    CASH
     ;
     
     public static Payment of(String payMethod) {

--- a/src/main/java/com/fastcampus/reserve/domain/product/room/Room.java
+++ b/src/main/java/com/fastcampus/reserve/domain/product/room/Room.java
@@ -36,65 +36,65 @@ public class Room extends BaseTimeEntity {
     @JoinColumn(name = "product_id")
     private Product product;
 
-	@Column(nullable = false, length = 255)
+    @Column(nullable = false, length = 255)
     private String name;
 
-	@Column(nullable = false)
-	private Integer price;
+    @Column(nullable = false)
+    private Integer price;
 
-	@Column(nullable = false)
-	private Integer stock;
+    @Column(nullable = false)
+    private Integer stock;
 
-	@Column(nullable = false)
-	private LocalTime checkInTime;
+    @Column(nullable = false)
+    private LocalTime checkInTime;
 
-	@Column(nullable = false)
-	private LocalTime checkOutTime;
+    @Column(nullable = false)
+    private LocalTime checkOutTime;
 
-	private Integer baseGuestCount;
-	private Integer maxGuestCount;
+    private Integer baseGuestCount;
+    private Integer maxGuestCount;
 
-	@Type(JsonType.class)
-	@Column(columnDefinition = "json")
-	private RoomFacilities roomFacilities;
+    @Type(JsonType.class)
+    @Column(columnDefinition = "json")
+    private RoomFacilities roomFacilities;
 
-	@OneToMany(
-			mappedBy = "room",
-			cascade = CascadeType.PERSIST, orphanRemoval = true
-	)
-	private final List<RoomImage> images = new ArrayList<>();
+    @OneToMany(
+            mappedBy = "room",
+            cascade = CascadeType.PERSIST, orphanRemoval = true
+    )
+    private final List<RoomImage> images = new ArrayList<>();
 
-	@Builder
-	private Room(
-			String name,
-			Integer price,
-			Integer stock,
-			LocalTime checkInTime,
-			LocalTime checkOutTime,
-			Integer baseGuestCount,
-			Integer maxGuestCount,
-			RoomFacilities roomFacilities
-	) {
-		this.name = name;
-		this.price = price;
-		this.stock = stock;
-		this.checkInTime = checkInTime;
-		this.checkOutTime = checkOutTime;
-		this.baseGuestCount = baseGuestCount;
-		this.maxGuestCount = maxGuestCount;
-		this.roomFacilities = roomFacilities;
-	}
+    @Builder
+    private Room(
+            String name,
+            Integer price,
+            Integer stock,
+            LocalTime checkInTime,
+            LocalTime checkOutTime,
+            Integer baseGuestCount,
+            Integer maxGuestCount,
+            RoomFacilities roomFacilities
+    ) {
+        this.name = name;
+        this.price = price;
+        this.stock = stock;
+        this.checkInTime = checkInTime;
+        this.checkOutTime = checkOutTime;
+        this.baseGuestCount = baseGuestCount;
+        this.maxGuestCount = maxGuestCount;
+        this.roomFacilities = roomFacilities;
+    }
 
-	public void addImage(RoomImage image) {
-		images.add(image);
-	}
+    public void addImage(RoomImage image) {
+        images.add(image);
+    }
 
-	public void registerProduct(Product product) {
-		if (!Objects.isNull(this.product)) {
-			this.product.getRooms().remove(this);
-		}
+    public void registerProduct(Product product) {
+        if (!Objects.isNull(this.product)) {
+            this.product.getRooms().remove(this);
+        }
 
-		this.product = product;
-		product.addRoom(this);
-	}
+        this.product = product;
+        product.addRoom(this);
+    }
 }

--- a/src/main/java/com/fastcampus/reserve/domain/product/room/Room.java
+++ b/src/main/java/com/fastcampus/reserve/domain/product/room/Room.java
@@ -2,9 +2,9 @@ package com.fastcampus.reserve.domain.product.room;
 
 import com.fastcampus.reserve.domain.BaseTimeEntity;
 import com.fastcampus.reserve.domain.product.Product;
+import io.hypersistence.utils.hibernate.type.json.JsonType;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
-import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -21,6 +21,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Type;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -42,6 +43,9 @@ public class Room extends BaseTimeEntity {
 	private Integer price;
 
 	@Column(nullable = false)
+	private Integer stock;
+
+	@Column(nullable = false)
 	private LocalTime checkInTime;
 
 	@Column(nullable = false)
@@ -50,7 +54,8 @@ public class Room extends BaseTimeEntity {
 	private Integer baseGuestCount;
 	private Integer maxGuestCount;
 
-	@Embedded
+	@Type(JsonType.class)
+	@Column(columnDefinition = "json")
 	private RoomFacilities roomFacilities;
 
 	@OneToMany(
@@ -63,6 +68,7 @@ public class Room extends BaseTimeEntity {
 	private Room(
 			String name,
 			Integer price,
+			Integer stock,
 			LocalTime checkInTime,
 			LocalTime checkOutTime,
 			Integer baseGuestCount,
@@ -71,6 +77,7 @@ public class Room extends BaseTimeEntity {
 	) {
 		this.name = name;
 		this.price = price;
+		this.stock = stock;
 		this.checkInTime = checkInTime;
 		this.checkOutTime = checkOutTime;
 		this.baseGuestCount = baseGuestCount;

--- a/src/main/java/com/fastcampus/reserve/domain/product/room/RoomFacilities.java
+++ b/src/main/java/com/fastcampus/reserve/domain/product/room/RoomFacilities.java
@@ -1,12 +1,10 @@
 package com.fastcampus.reserve.domain.product.room;
 
-import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Embeddable
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RoomFacilities {

--- a/src/main/java/com/fastcampus/reserve/infrestructure/RedisServiceImpl.java
+++ b/src/main/java/com/fastcampus/reserve/infrestructure/RedisServiceImpl.java
@@ -1,0 +1,60 @@
+package com.fastcampus.reserve.infrestructure;
+
+import static com.fastcampus.reserve.common.response.ErrorCode.COMMON_SYSTEM_ERROR;
+
+import com.fastcampus.reserve.common.exception.CustomException;
+import com.fastcampus.reserve.domain.RedisService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RedisServiceImpl implements RedisService {
+
+    private final StringRedisTemplate redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public <T> Optional<T> get(String key, Class<T> type) {
+        String serializedValue = redisTemplate.opsForValue().get(key);
+        try {
+            return Optional.of(objectMapper.readValue(serializedValue, type));
+        } catch (Exception e) {
+            throw new CustomException(COMMON_SYSTEM_ERROR);
+        }
+    }
+
+    @Override
+    public void set(String key, Object value, Long expiredTime) {
+        try {
+            String serializedValue = objectMapper.writeValueAsString(value);
+            redisTemplate.opsForValue().set(key, serializedValue, expiredTime, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            throw new CustomException(COMMON_SYSTEM_ERROR);
+        }
+    }
+
+    @Override
+    public boolean setIfAbsent(String key, Object value, Long expiredTime) {
+        try {
+            String serializedValue = objectMapper.writeValueAsString(value);
+            return Boolean.TRUE.equals(
+                    redisTemplate.opsForValue().setIfAbsent(
+                            key,
+                            serializedValue,
+                            expiredTime, TimeUnit.SECONDS
+                    ));
+        } catch (Exception e) {
+            throw new CustomException(COMMON_SYSTEM_ERROR);
+        }
+    }
+
+    @Override
+    public boolean delete(String key) {
+        return Boolean.TRUE.equals(redisTemplate.delete(key));
+    }
+}

--- a/src/main/java/com/fastcampus/reserve/interfaces/order/OrderController.java
+++ b/src/main/java/com/fastcampus/reserve/interfaces/order/OrderController.java
@@ -1,0 +1,33 @@
+package com.fastcampus.reserve.interfaces.order;
+
+import com.fastcampus.reserve.application.order.OrderFacade;
+import com.fastcampus.reserve.common.response.CommonResponse;
+import com.fastcampus.reserve.interfaces.order.dto.request.RegisterOrderRequest;
+import com.fastcampus.reserve.interfaces.order.dto.response.RegisterOrderResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/orders")
+public class OrderController {
+
+    private final OrderFacade orderFacade;
+    private final OrderDtoMapper mapper;
+
+    @PostMapping
+    public CommonResponse<RegisterOrderResponse> registerOrder(
+            @RequestBody @Valid RegisterOrderRequest request
+    ) {
+        // todo: Spring Security Authentication 정보에서 User ID 조회야 한다.
+        Long userId = 1L;
+        var orderToken = orderFacade.registerOrder(mapper.of(request, userId));
+        return CommonResponse.ok(mapper.of(orderToken));
+    }
+}

--- a/src/main/java/com/fastcampus/reserve/interfaces/order/OrderDtoMapper.java
+++ b/src/main/java/com/fastcampus/reserve/interfaces/order/OrderDtoMapper.java
@@ -1,0 +1,24 @@
+package com.fastcampus.reserve.interfaces.order;
+
+import com.fastcampus.reserve.domain.order.dto.request.RegisterOrderDto;
+import com.fastcampus.reserve.domain.order.dto.request.RegisterOrderItemDto;
+import com.fastcampus.reserve.interfaces.order.dto.request.RegisterOrderItemRequest;
+import com.fastcampus.reserve.interfaces.order.dto.request.RegisterOrderRequest;
+import com.fastcampus.reserve.interfaces.order.dto.response.RegisterOrderResponse;
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
+
+@Mapper(
+        componentModel = "spring",
+        injectionStrategy = InjectionStrategy.CONSTRUCTOR,
+        unmappedTargetPolicy = ReportingPolicy.ERROR
+)
+public interface OrderDtoMapper {
+
+    RegisterOrderItemDto of(RegisterOrderItemRequest request);
+
+    RegisterOrderDto of(RegisterOrderRequest request, Long userId);
+
+    RegisterOrderResponse of(String orderToken);
+}

--- a/src/main/java/com/fastcampus/reserve/interfaces/order/dto/request/RegisterOrderItemRequest.java
+++ b/src/main/java/com/fastcampus/reserve/interfaces/order/dto/request/RegisterOrderItemRequest.java
@@ -1,0 +1,44 @@
+package com.fastcampus.reserve.interfaces.order.dto.request;
+
+import static com.fastcampus.reserve.common.response.ErrorCode.COMMON_INVALID_PARAMETER;
+
+import com.fastcampus.reserve.common.exception.CustomException;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record RegisterOrderItemRequest(
+        @NotNull(message = "숙소 ID 는 필수 값 입니다.")
+        Long productId,
+
+        @NotNull(message = "방 ID 는 필수 값 입니다.")
+        Long roomId,
+
+        @NotNull(message = "체크인 날짜는 필수 값 입니다.")
+        LocalDate checkInDate,
+
+        @NotNull(message = "체크인 시간은 필수 값 입니다.")
+        LocalTime checkInTime,
+
+        @NotNull(message = "체크아웃 날짜는 필수 값 입니다.")
+        LocalDate checkOutDate,
+
+        @NotNull(message = "체크아웃 시간은 필수 값 입니다.")
+        LocalTime checkOutTime,
+
+        @NotNull(message = "숙박 인원은 필수 값 입니다.")
+        @Min(value = 0, message = "숙박 인원은 0명 이상 값 입니다.")
+        Integer guestCount,
+
+        @NotNull(message = "예약 가격은 필수 값 입니다.")
+        @Min(value = 0, message = "예약 가격은 0원 이상 값 입니다.")
+        Integer price
+) {
+
+    public RegisterOrderItemRequest {
+        if (checkInDate.isEqual(checkOutDate) || checkInDate.isAfter(checkOutDate)) {
+            throw new CustomException(COMMON_INVALID_PARAMETER);
+        }
+    }
+}

--- a/src/main/java/com/fastcampus/reserve/interfaces/order/dto/request/RegisterOrderRequest.java
+++ b/src/main/java/com/fastcampus/reserve/interfaces/order/dto/request/RegisterOrderRequest.java
@@ -1,0 +1,16 @@
+package com.fastcampus.reserve.interfaces.order.dto.request;
+
+import static com.fastcampus.reserve.common.utils.ValidateUtils.emptyCheck;
+
+import jakarta.validation.Valid;
+import java.util.List;
+
+public record RegisterOrderRequest(
+        @Valid
+        List<RegisterOrderItemRequest> registerOrderItems
+) {
+
+    public RegisterOrderRequest {
+        emptyCheck(registerOrderItems);
+    }
+}

--- a/src/main/java/com/fastcampus/reserve/interfaces/order/dto/response/RegisterOrderResponse.java
+++ b/src/main/java/com/fastcampus/reserve/interfaces/order/dto/response/RegisterOrderResponse.java
@@ -1,0 +1,7 @@
+package com.fastcampus.reserve.interfaces.order.dto.response;
+
+public record RegisterOrderResponse(
+        String orderToken
+) {
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,6 +18,10 @@ spring:
         show_sql: true
         format_sql: true
 
+redis:
+  host: localhost
+  port: 6379
+
 security:
   jwt:
     secret: Security-Pilot-Project_Secret-Key

--- a/src/test/java/com/fastcampus/reserve/common/ApiDocumentation.java
+++ b/src/test/java/com/fastcampus/reserve/common/ApiDocumentation.java
@@ -1,0 +1,54 @@
+package com.fastcampus.reserve.common;
+
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.modifyUris;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.snippet.Attributes.key;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.operation.preprocess.OperationRequestPreprocessor;
+import org.springframework.restdocs.operation.preprocess.OperationResponsePreprocessor;
+import org.springframework.restdocs.snippet.Attributes.Attribute;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@AutoConfigureRestDocs
+@ExtendWith(RestDocumentationExtension.class)
+public abstract class ApiDocumentation {
+
+    private static final String BASE_URL = "localhost";
+
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+    @Autowired
+    protected MockMvc mockMvc;
+
+    protected OperationRequestPreprocessor getDocumentRequest() {
+        return preprocessRequest(
+                modifyUris()
+                        .host(BASE_URL)
+                        .removePort(),
+                prettyPrint());
+    }
+
+    protected OperationResponsePreprocessor getDocumentResponse() {
+        return preprocessResponse(prettyPrint());
+    }
+
+    protected Attribute getTimeFormat() {
+        return key("format").value("hh:mm");
+    }
+
+    protected Attribute getDateFormat() {
+        return key("format").value("yyy-MM-dd");
+    }
+}

--- a/src/test/java/com/fastcampus/reserve/common/ApiTest.java
+++ b/src/test/java/com/fastcampus/reserve/common/ApiTest.java
@@ -1,0 +1,21 @@
+package com.fastcampus.reserve.common;
+
+import io.restassured.RestAssured;
+import io.restassured.specification.RequestSpecification;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+@ExtendWith(DatabaseClearExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public abstract class ApiTest {
+
+    @LocalServerPort
+    private int port;
+
+    @BeforeEach
+    void init() {
+        RestAssured.port = port;
+    }
+}

--- a/src/test/java/com/fastcampus/reserve/common/DatabaseCleaner.java
+++ b/src/test/java/com/fastcampus/reserve/common/DatabaseCleaner.java
@@ -1,0 +1,45 @@
+package com.fastcampus.reserve.common;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class DatabaseCleaner {
+
+    private final List<String> tableNames = new ArrayList<>();
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @SuppressWarnings("unchecked")
+    @PostConstruct
+    private void findDatabaseTableNames() {
+        List<Object[]> tableInfos = entityManager.createNativeQuery("SHOW TABLES").getResultList();
+        for (Object[] tableInfo : tableInfos) {
+            String tableName = (String) tableInfo[0];
+            tableNames.add(tableName);
+        }
+    }
+
+    private void truncate() {
+        entityManager.createNativeQuery(String.format("SET FOREIGN_KEY_CHECKS %d", 0))
+            .executeUpdate();
+        for (String tableName : tableNames) {
+            entityManager.createNativeQuery(String.format("TRUNCATE TABLE %s", tableName))
+                .executeUpdate();
+        }
+        entityManager.createNativeQuery(String.format("SET FOREIGN_KEY_CHECKS %d", 1))
+            .executeUpdate();
+    }
+
+    @Transactional
+    public void clear() {
+        entityManager.clear();
+        truncate();
+    }
+}

--- a/src/test/java/com/fastcampus/reserve/common/DatabaseClearExtension.java
+++ b/src/test/java/com/fastcampus/reserve/common/DatabaseClearExtension.java
@@ -1,0 +1,20 @@
+package com.fastcampus.reserve.common;
+
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+public class DatabaseClearExtension implements BeforeEachCallback {
+
+    @Override
+    public void beforeEach(ExtensionContext context) {
+        DatabaseCleaner databaseCleaner = getDataCleaner(context);
+        databaseCleaner.clear();
+    }
+
+    private DatabaseCleaner getDataCleaner(ExtensionContext extensionContext) {
+        return SpringExtension
+                .getApplicationContext(extensionContext)
+                .getBean(DatabaseCleaner.class);
+    }
+}

--- a/src/test/java/com/fastcampus/reserve/domain/order/OrderServiceTest.java
+++ b/src/test/java/com/fastcampus/reserve/domain/order/OrderServiceTest.java
@@ -1,0 +1,54 @@
+package com.fastcampus.reserve.domain.order;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+
+import com.fastcampus.reserve.domain.RedisService;
+import com.fastcampus.reserve.domain.order.dto.request.RegisterOrderDto;
+import com.fastcampus.reserve.domain.order.dto.request.RegisterOrderItemDto;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@DisplayName("주문 검증")
+@ExtendWith(MockitoExtension.class)
+class OrderServiceTest {
+
+    @InjectMocks
+    private OrderService orderService;
+
+    @Mock
+    private RedisService redisService;
+
+    @Test
+    void registerOrder_성공() {
+        // given
+        RegisterOrderItemDto registerOrderItemDto = new RegisterOrderItemDto(
+                -1L,
+                -1L,
+                LocalDate.now(),
+                LocalTime.of(15, 0),
+                LocalDate.now().plusDays(1),
+                LocalTime.of(12, 0),
+                2,
+                120000
+        );
+        RegisterOrderDto request = new RegisterOrderDto(-1L, List.of(registerOrderItemDto));
+
+        doNothing().when(redisService)
+                .set(any(String.class), any(RegisterOrder.class), any(Long.class));
+
+        // when
+        String result = orderService.registerOrder(request);
+
+        // then
+        assertThat(result).isNotNull();
+    }
+}

--- a/src/test/java/com/fastcampus/reserve/domain/order/OrderServiceTest.java
+++ b/src/test/java/com/fastcampus/reserve/domain/order/OrderServiceTest.java
@@ -28,7 +28,8 @@ class OrderServiceTest {
     private RedisService redisService;
 
     @Test
-    void registerOrder_성공() {
+    @DisplayName("숙소 예약 신청 성공")
+    void registerOrder() {
         // given
         RegisterOrderItemDto registerOrderItemDto = new RegisterOrderItemDto(
                 -1L,

--- a/src/test/java/com/fastcampus/reserve/interfaces/order/OrderControllerTest.java
+++ b/src/test/java/com/fastcampus/reserve/interfaces/order/OrderControllerTest.java
@@ -1,0 +1,51 @@
+package com.fastcampus.reserve.interfaces.order;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fastcampus.reserve.common.ApiTest;
+import com.fastcampus.reserve.interfaces.order.dto.request.RegisterOrderItemRequest;
+import com.fastcampus.reserve.interfaces.order.dto.request.RegisterOrderRequest;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+class OrderControllerTest extends ApiTest {
+
+    @Test
+    void registerOrder() {
+        // given
+        RegisterOrderItemRequest registerOrderItemRequest = new RegisterOrderItemRequest(
+                -1L,
+                -1L,
+                LocalDate.now(),
+                LocalTime.of(15, 0),
+                LocalDate.now().plusDays(1),
+                LocalTime.of(12, 0),
+                4,
+                99000
+        );
+
+        RegisterOrderRequest request = new RegisterOrderRequest(List.of(registerOrderItemRequest));
+
+        String url = "/v1/orders";
+
+        // when
+        ExtractableResponse<Response> result = RestAssured
+                .given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(request)
+                .when()
+                .post(url)
+                .then().log().all()
+                .extract();
+
+        // then
+        assertThat(result.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+}

--- a/src/test/java/com/fastcampus/reserve/restdocs/order/OrderDocumentationTest.java
+++ b/src/test/java/com/fastcampus/reserve/restdocs/order/OrderDocumentationTest.java
@@ -37,10 +37,10 @@ public class OrderDocumentationTest extends ApiDocumentation {
         byte[] param = objectMapper.writeValueAsBytes(registerOrder);
 
         this.mockMvc.perform(
-                post("/v1/orders")
-                        .accept(MediaType.APPLICATION_JSON)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(param)
+                        post("/v1/orders")
+                                .accept(MediaType.APPLICATION_JSON)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(param)
                 )
                 .andExpect(status().isOk())
                 .andDo(document(

--- a/src/test/java/com/fastcampus/reserve/restdocs/order/OrderDocumentationTest.java
+++ b/src/test/java/com/fastcampus/reserve/restdocs/order/OrderDocumentationTest.java
@@ -1,0 +1,81 @@
+package com.fastcampus.reserve.restdocs.order;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.JsonFieldType.ARRAY;
+import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fastcampus.reserve.common.ApiDocumentation;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+
+public class OrderDocumentationTest extends ApiDocumentation {
+
+    @Test
+    void registerOrder() throws Exception {
+        Map<String, Object> registerOrderItems = new HashMap<>();
+        registerOrderItems.put("productId", -1L);
+        registerOrderItems.put("roomId", -1L);
+        registerOrderItems.put("checkInDate", "2023-11-23");
+        registerOrderItems.put("checkInTime", "15:00");
+        registerOrderItems.put("checkOutDate", "2023-11-25");
+        registerOrderItems.put("checkOutTime", "12:00");
+        registerOrderItems.put("guestCount", 4);
+        registerOrderItems.put("price", 99000);
+
+        Map<String, Object> registerOrder = new HashMap<>();
+        registerOrder.put("registerOrderItems", List.of(registerOrderItems));
+
+        byte[] param = objectMapper.writeValueAsBytes(registerOrder);
+
+        this.mockMvc.perform(
+                post("/v1/orders")
+                        .accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(param)
+                )
+                .andExpect(status().isOk())
+                .andDo(document(
+                        "order/registerOrder/success",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        requestFields(
+                                fieldWithPath("registerOrderItems").type(ARRAY)
+                                        .description("예약 신청 정보 목록").optional(),
+                                fieldWithPath("registerOrderItems[].productId").type(NUMBER)
+                                        .description("숙박 업소 ID"),
+                                fieldWithPath("registerOrderItems[].roomId").type(NUMBER)
+                                        .description("방 ID"),
+                                fieldWithPath("registerOrderItems[].checkInDate").type(STRING)
+                                        .attributes(getDateFormat())
+                                        .description("체크인 날짜"),
+                                fieldWithPath("registerOrderItems[].checkInTime").type(STRING)
+                                        .attributes(getTimeFormat())
+                                        .description("체크인 시간"),
+                                fieldWithPath("registerOrderItems[].checkOutDate").type(STRING)
+                                        .attributes(getDateFormat())
+                                        .description("체크아웃 날짜"),
+                                fieldWithPath("registerOrderItems[].checkOutTime").type(STRING)
+                                        .attributes(getTimeFormat())
+                                        .description("체크아웃 시간"),
+                                fieldWithPath("registerOrderItems[].guestCount").type(NUMBER)
+                                        .description("예약 인원"),
+                                fieldWithPath("registerOrderItems[].price").type(NUMBER)
+                                        .description("예약 가격")
+                        ),
+                        responseFields(
+                                fieldWithPath("status").ignored(),
+                                fieldWithPath("data.orderToken").type(STRING)
+                                        .description("임시 예약 번호")
+                        )
+                ));
+    }
+}

--- a/src/test/resources/org/springframework/restdocs/templates/request-fields.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/request-fields.snippet
@@ -1,0 +1,13 @@
+==== Request Fields
+|===
+|필드명|타입|필수값|양식|설명
+
+{{#fields}}
+|{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+|{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
+|{{^optional}}true{{/optional}}
+|{{#format}}{{.}}{{/format}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+
+{{/fields}}
+|===


### PR DESCRIPTION
close #13

결제하기 전 예약을 신청하는 기능입니다.

실제 DB에 저장하지 않고 Redis에만 저장합니다.
- Key 값은 UUID를 통해 생성합니다.
- TTL은 1시간으로 지정하여, 결제를 진행하지 않은경우 1시간 후에 자동 삭제되도록 하였습니다.
- 결제가 진행되면 Redis에서 지우는 방식으로 진행 할 예정입니다.

위에 방식으로 구현했지만, TTL을 5분 정도로 짧게 가져가면 
별도로 결제가 진행됐을 때, 지우지 않아도 될것 같은데 의견 주시면 감사하겠습니다!

- Redis는 Spring Data JPA 대신 RedisTemplate를 사용하고, 다양한 클래스에 적용하기 위해 별도의 RedisServiceImpl를 구현했습니다.
- ObjectMapper는 null 값에 대해서 포함하지 않고, LocalDate, LocaTime, LocalDateTime 등 Java 8의 Time 패키지를 사용하기 위해 별도 모듈을 추가 설정 추가하고, 별도의 @Bean으로 등록했습니다.
- Spring REST Docs와 통합 테스트는 분리해서 진행했습니다.


TODO 사항으로 Security 설정 완료 후, Controller 파라미터로 Authentication에서 정보를 조회하는 설정을 하도록 하겠습니다.
