### PR TITLE
DB에 OpenAPI 데이터 채워넣기

### DIFF
--- a/src/main/java/com/fastcampus/reserve/domain/product/Product.java
+++ b/src/main/java/com/fastcampus/reserve/domain/product/Product.java
@@ -5,10 +5,6 @@ import com.fastcampus.reserve.domain.product.room.Room;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import java.util.ArrayList;
@@ -22,47 +18,36 @@ import lombok.NoArgsConstructor;
 @Entity
 public class Product extends BaseTimeEntity {
 
-    @Id
-    private Long id;
-
-    @Column(nullable = false, length = 255)
-    private String name;
-
-    @Column(length = 20)
-    private String category;
-
-    @Column(length = 3000)
-    private String description;
-
-    @Column(length = 20)
-    private String zipCode;
-
-    @Column(length = 100)
-    private String address;
-
-    @Column(length = 30)
-    private String longitude;
-
-    @Column(length = 30)
-    private String latitude;
-
-    @Column(length = 30)
-    private String area;
-
-    @Column(length = 30)
-    private String sigungu;
-
     @OneToMany(
-            mappedBy = "product",
-            cascade = CascadeType.PERSIST, orphanRemoval = true
+        mappedBy = "product",
+        cascade = CascadeType.PERSIST, orphanRemoval = true
     )
     private final List<ProductImage> images = new ArrayList<>();
-
     @OneToMany(
-            mappedBy = "product",
-            cascade = CascadeType.PERSIST, orphanRemoval = true
+        mappedBy = "product",
+        cascade = CascadeType.PERSIST, orphanRemoval = true
     )
     private final List<Room> rooms = new ArrayList<>();
+    @Id
+    private Long id;
+    @Column(nullable = false, length = 255)
+    private String name;
+    @Column(length = 20)
+    private String category;
+    @Column(length = 3000)
+    private String description;
+    @Column(length = 20)
+    private String zipCode;
+    @Column(length = 100)
+    private String address;
+    @Column(length = 30)
+    private String longitude;
+    @Column(length = 30)
+    private String latitude;
+    @Column(length = 30)
+    private String area;
+    @Column(length = 30)
+    private String sigungu;
 
     public Product(String name, String category, String description, String zipCode, String address,
                    String longitude, String latitude, String area, String sigungu) {

--- a/src/main/java/com/fastcampus/reserve/domain/product/Product.java
+++ b/src/main/java/com/fastcampus/reserve/domain/product/Product.java
@@ -10,6 +10,7 @@ import jakarta.persistence.OneToMany;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -60,8 +61,9 @@ public class Product extends BaseTimeEntity {
     private final List<Room> rooms = new ArrayList<>();
 
     @Builder
-    private Product(String name, String category, String description, String zipCode, String address,
-                   String longitude, String latitude, String area, String sigungu) {
+    private Product(String name, String category, String description, String zipCode,
+                    String address, String longitude, String latitude, String area,
+                    String sigungu) {
         this.name = name;
         this.category = category;
         this.description = description;

--- a/src/main/java/com/fastcampus/reserve/domain/product/Product.java
+++ b/src/main/java/com/fastcampus/reserve/domain/product/Product.java
@@ -18,6 +18,36 @@ import lombok.NoArgsConstructor;
 @Entity
 public class Product extends BaseTimeEntity {
 
+    @Id
+    private Long id;
+
+    @Column(nullable = false, length = 255)
+    private String name;
+
+    @Column(length = 20)
+    private String category;
+
+    @Column(length = 3000)
+    private String description;
+
+    @Column(length = 20)
+    private String zipCode;
+
+    @Column(length = 100)
+    private String address;
+
+    @Column(length = 30)
+    private String longitude;
+
+    @Column(length = 30)
+    private String latitude;
+
+    @Column(length = 30)
+    private String area;
+    
+    @Column(length = 30)
+    private String sigungu;
+
     @OneToMany(
         mappedBy = "product",
         cascade = CascadeType.PERSIST, orphanRemoval = true
@@ -28,28 +58,9 @@ public class Product extends BaseTimeEntity {
         cascade = CascadeType.PERSIST, orphanRemoval = true
     )
     private final List<Room> rooms = new ArrayList<>();
-    @Id
-    private Long id;
-    @Column(nullable = false, length = 255)
-    private String name;
-    @Column(length = 20)
-    private String category;
-    @Column(length = 3000)
-    private String description;
-    @Column(length = 20)
-    private String zipCode;
-    @Column(length = 100)
-    private String address;
-    @Column(length = 30)
-    private String longitude;
-    @Column(length = 30)
-    private String latitude;
-    @Column(length = 30)
-    private String area;
-    @Column(length = 30)
-    private String sigungu;
 
-    public Product(String name, String category, String description, String zipCode, String address,
+    @Builder
+    private Product(String name, String category, String description, String zipCode, String address,
                    String longitude, String latitude, String area, String sigungu) {
         this.name = name;
         this.category = category;

--- a/src/main/java/com/fastcampus/reserve/domain/product/Product.java
+++ b/src/main/java/com/fastcampus/reserve/domain/product/Product.java
@@ -23,16 +23,15 @@ import lombok.NoArgsConstructor;
 public class Product extends BaseTimeEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(nullable = false, length = 255)
     private String name;
 
-    @Enumerated(EnumType.STRING)
-    private CategoryType category;
+    @Column(length = 20)
+    private String category;
 
-    @Column(length = 1000)
+    @Column(length = 3000)
     private String description;
 
     @Column(length = 20)
@@ -47,6 +46,12 @@ public class Product extends BaseTimeEntity {
     @Column(length = 30)
     private String latitude;
 
+    @Column(length = 30)
+    private String area;
+
+    @Column(length = 30)
+    private String sigungu;
+
     @OneToMany(
             mappedBy = "product",
             cascade = CascadeType.PERSIST, orphanRemoval = true
@@ -59,15 +64,8 @@ public class Product extends BaseTimeEntity {
     )
     private final List<Room> rooms = new ArrayList<>();
 
-    public Product(
-            String name,
-            CategoryType category,
-            String description,
-            String zipCode,
-            String address,
-            String longitude,
-            String latitude
-    ) {
+    public Product(String name, String category, String description, String zipCode, String address,
+                   String longitude, String latitude, String area, String sigungu) {
         this.name = name;
         this.category = category;
         this.description = description;
@@ -75,6 +73,8 @@ public class Product extends BaseTimeEntity {
         this.address = address;
         this.longitude = longitude;
         this.latitude = latitude;
+        this.area = area;
+        this.sigungu = sigungu;
     }
 
     public void addImage(ProductImage image) {
@@ -83,9 +83,5 @@ public class Product extends BaseTimeEntity {
 
     public void addRoom(Room room) {
         rooms.add(room);
-    }
-
-    public enum CategoryType {
-        HOTEL, MOTEL, PENSION
     }
 }

--- a/src/main/java/com/fastcampus/reserve/domain/product/room/Room.java
+++ b/src/main/java/com/fastcampus/reserve/domain/product/room/Room.java
@@ -4,16 +4,12 @@ import com.fastcampus.reserve.domain.BaseTimeEntity;
 import com.fastcampus.reserve.domain.product.Product;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
-import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
-import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -27,68 +23,58 @@ import lombok.NoArgsConstructor;
 @Entity
 public class Room extends BaseTimeEntity {
 
+    @OneToMany(
+        mappedBy = "room",
+        cascade = CascadeType.PERSIST, orphanRemoval = true
+    )
+    private final List<RoomImage> images = new ArrayList<>();
     @Id
     private Long id;
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "product_id")
     private Product product;
-
-	@Column(nullable = false, length = 255)
+    @Column(nullable = false, length = 255)
     private String name;
+    @Column(nullable = false)
+    private Integer price;
+    @Column(nullable = false)
+    private Integer stock;
+    @Column(nullable = false, length = 30)
+    private String checkInTime;
+    @Column(nullable = false, length = 30)
+    private String checkOutTime;
+    @Column(nullable = false)
+    private Integer baseGuestCount;
+    @Column(nullable = false)
+    private Integer maxGuestCount;
+    @Column(length = 3000)
+    private String roomFacilities;
 
-	@Column(nullable = false)
-	private Integer price;
+    @Builder
+    private Room(Product product, String name, Integer price, Integer stock, String checkInTime,
+                 String checkOutTime, Integer baseGuestCount, Integer maxGuestCount,
+                 String roomFacilities) {
+        this.product = product;
+        this.name = name;
+        this.price = price;
+        this.stock = stock;
+        this.checkInTime = checkInTime;
+        this.checkOutTime = checkOutTime;
+        this.baseGuestCount = baseGuestCount;
+        this.maxGuestCount = maxGuestCount;
+        this.roomFacilities = roomFacilities;
+    }
 
-	@Column(nullable = false)
-	private Integer stock;
+    public void addImage(RoomImage image) {
+        images.add(image);
+    }
 
-	@Column(nullable = false, length = 30)
-	private String checkInTime;
+    public void registerProduct(Product product) {
+        if (!Objects.isNull(this.product)) {
+            this.product.getRooms().remove(this);
+        }
 
-	@Column(nullable = false, length = 30)
-	private String checkOutTime;
-
-	@Column(nullable = false)
-	private Integer baseGuestCount;
-
-	@Column(nullable = false)
-	private Integer maxGuestCount;
-
-	@Column(length = 3000)
-	private String roomFacilities;
-
-	@OneToMany(
-			mappedBy = "room",
-			cascade = CascadeType.PERSIST, orphanRemoval = true
-	)
-	private final List<RoomImage> images = new ArrayList<>();
-
-	@Builder
-	private Room(Product product, String name, Integer price, Integer stock, String checkInTime,
-				String checkOutTime, Integer baseGuestCount, Integer maxGuestCount,
-				String roomFacilities) {
-		this.product = product;
-		this.name = name;
-		this.price = price;
-		this.stock = stock;
-		this.checkInTime = checkInTime;
-		this.checkOutTime = checkOutTime;
-		this.baseGuestCount = baseGuestCount;
-		this.maxGuestCount = maxGuestCount;
-		this.roomFacilities = roomFacilities;
-	}
-
-	public void addImage(RoomImage image) {
-		images.add(image);
-	}
-
-	public void registerProduct(Product product) {
-		if (!Objects.isNull(this.product)) {
-			this.product.getRooms().remove(this);
-		}
-
-		this.product = product;
-		product.addRoom(this);
-	}
+        this.product = product;
+        product.addRoom(this);
+    }
 }

--- a/src/main/java/com/fastcampus/reserve/domain/product/room/Room.java
+++ b/src/main/java/com/fastcampus/reserve/domain/product/room/Room.java
@@ -28,7 +28,6 @@ import lombok.NoArgsConstructor;
 public class Room extends BaseTimeEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -42,16 +41,22 @@ public class Room extends BaseTimeEntity {
 	private Integer price;
 
 	@Column(nullable = false)
-	private LocalTime checkInTime;
+	private Integer stock;
+
+	@Column(nullable = false, length = 30)
+	private String checkInTime;
+
+	@Column(nullable = false, length = 30)
+	private String checkOutTime;
 
 	@Column(nullable = false)
-	private LocalTime checkOutTime;
-
 	private Integer baseGuestCount;
+
+	@Column(nullable = false)
 	private Integer maxGuestCount;
 
-	@Embedded
-	private RoomFacilities roomFacilities;
+	@Column(length = 3000)
+	private String roomFacilities;
 
 	@OneToMany(
 			mappedBy = "room",
@@ -60,17 +65,13 @@ public class Room extends BaseTimeEntity {
 	private final List<RoomImage> images = new ArrayList<>();
 
 	@Builder
-	private Room(
-			String name,
-			Integer price,
-			LocalTime checkInTime,
-			LocalTime checkOutTime,
-			Integer baseGuestCount,
-			Integer maxGuestCount,
-			RoomFacilities roomFacilities
-	) {
+	private Room(Product product, String name, Integer price, Integer stock, String checkInTime,
+				String checkOutTime, Integer baseGuestCount, Integer maxGuestCount,
+				String roomFacilities) {
+		this.product = product;
 		this.name = name;
 		this.price = price;
+		this.stock = stock;
 		this.checkInTime = checkInTime;
 		this.checkOutTime = checkOutTime;
 		this.baseGuestCount = baseGuestCount;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,6 +17,7 @@ spring:
       hibernate:
         show_sql: true
         format_sql: true
+    defer-datasource-initialization: true
 
 security:
   jwt:


### PR DESCRIPTION
closes #3

- Room, Product의 Entity 구조를 변경하였습니다.
  - OpenAPI 데이터 형식이 기존 Entity 구조와 맞지 않았음
- Room의 category쪽이 Enum 타입으로 돼있던 부분을 String으로 변경했습니다
  1. 자바 내에서 Enum을 쓸 일이 없을 것 같아서 (그냥 값 그대로 검색하면 되고, 값 그대로 프론트에게 보내주면 됨)
  2. OpenAPI 데이터 채워넣는 작업도 충분히 고통스러운데 Enum 매핑까지 하기 부담스러워서
- 총 518개의 데이터가 추가되었습니다. (전체 3315개 중 숙소 이미지가 있으며, 객실이 1개이상 있으며, 객실마다 이미지가 있는 숙소만 걸러냈음)

data.sql 파일에 쿼리가 약 1만개 들어가긴 하는데
이거 실행되는데에 별로 시간 안 드는 것 같습니다. (직접 실행해보셔도 됩니다)

ERD 확정되기 전까지는 data.sql 파일 두었으면 좋겠습니다. (ERD 변경될때마다 data.sql 서버 배포쪽 재설정 하는거 생각만해도 너무 번거로워서)

생각보다 정말 고통스러운 작업이였네요