### PR TITLE
Feature/17 주문 내역 상세 조회 기능 구현

### DIFF
--- a/src/main/java/com/fastcampus/reserve/application/order/OrderFacade.java
+++ b/src/main/java/com/fastcampus/reserve/application/order/OrderFacade.java
@@ -3,6 +3,7 @@ package com.fastcampus.reserve.application.order;
 import com.fastcampus.reserve.domain.order.OrderService;
 import com.fastcampus.reserve.domain.order.dto.request.PaymentDto;
 import com.fastcampus.reserve.domain.order.dto.request.RegisterOrderDto;
+import com.fastcampus.reserve.domain.order.dto.response.OrderInfoDto;
 import com.fastcampus.reserve.domain.order.dto.response.RegisterOrderInfoDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,5 +26,9 @@ public class OrderFacade {
 
     public RegisterOrderInfoDto findRegisterOrder(String orderToken) {
         return orderService.findRegisterOrder(orderToken);
+    }
+
+    public OrderInfoDto findOrder(Long orderId) {
+        return orderService.findOrder(orderId);
     }
 }

--- a/src/main/java/com/fastcampus/reserve/common/response/ErrorCode.java
+++ b/src/main/java/com/fastcampus/reserve/common/response/ErrorCode.java
@@ -21,6 +21,7 @@ public enum ErrorCode {
     NOT_EXIST_REGISTER_ORDER(HttpStatus.BAD_REQUEST, "존재하지 않는 예약 신청입니다."),
     NOT_EXIST_IMAGE(HttpStatus.INTERNAL_SERVER_ERROR, "이미지가 존재하지 않습니다."),
     NOT_MATCH_TOTAL_PRICE(HttpStatus.BAD_REQUEST, "결제 금액이 일치하지 않습니다."),
+    NO_SUCH_ORDER(HttpStatus.BAD_REQUEST, "존재하지 않는 주문 내역입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/fastcampus/reserve/domain/BaseTimeEntity.java
+++ b/src/main/java/com/fastcampus/reserve/domain/BaseTimeEntity.java
@@ -4,12 +4,12 @@ import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
+import lombok.Getter;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+@Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseTimeEntity {

--- a/src/main/java/com/fastcampus/reserve/domain/order/Order.java
+++ b/src/main/java/com/fastcampus/reserve/domain/order/Order.java
@@ -75,4 +75,10 @@ public class Order extends BaseTimeEntity {
     public void addOrderItem(OrderItem orderItem) {
         orderItems.add(orderItem);
     }
+
+    public int calcTotalPrice() {
+        return orderItems.stream()
+                .mapToInt(OrderItem::getPrice)
+                .sum();
+    }
 }

--- a/src/main/java/com/fastcampus/reserve/domain/order/Order.java
+++ b/src/main/java/com/fastcampus/reserve/domain/order/Order.java
@@ -20,7 +20,6 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -75,15 +74,5 @@ public class Order extends BaseTimeEntity {
 
     public void addOrderItem(OrderItem orderItem) {
         orderItems.add(orderItem);
-    }
-
-    @Getter
-    @RequiredArgsConstructor
-    public enum StatusType {
-        INIT("예약 신청"),
-        COMPLETE("결제 완료"),
-        ;
-
-        private final String description;
     }
 }

--- a/src/main/java/com/fastcampus/reserve/domain/order/Order.java
+++ b/src/main/java/com/fastcampus/reserve/domain/order/Order.java
@@ -36,6 +36,12 @@ public class Order extends BaseTimeEntity {
     private Long userId;
 
     @Column(length = 100)
+    private String reserveName;
+
+    @Column(length = 50)
+    private String reservePhone;
+
+    @Column(length = 100)
     private String userName;
 
     @Column(length = 50)
@@ -53,11 +59,15 @@ public class Order extends BaseTimeEntity {
     @Builder
     private Order(
             Long userId,
+            String reserveName,
+            String reservePhone,
             String userName,
             String userPhone,
             Payment payment
     ) {
         this.userId = userId;
+        this.reserveName = reserveName;
+        this.reservePhone = reservePhone;
         this.userName = userName;
         this.userPhone = userPhone;
         this.payment = payment;

--- a/src/main/java/com/fastcampus/reserve/domain/order/OrderReader.java
+++ b/src/main/java/com/fastcampus/reserve/domain/order/OrderReader.java
@@ -1,0 +1,6 @@
+package com.fastcampus.reserve.domain.order;
+
+public interface OrderReader {
+
+    Order findByIdWithOrderItem(Long orderId);
+}

--- a/src/main/java/com/fastcampus/reserve/domain/order/OrderService.java
+++ b/src/main/java/com/fastcampus/reserve/domain/order/OrderService.java
@@ -6,6 +6,7 @@ import com.fastcampus.reserve.common.exception.CustomException;
 import com.fastcampus.reserve.domain.RedisService;
 import com.fastcampus.reserve.domain.order.dto.request.PaymentDto;
 import com.fastcampus.reserve.domain.order.dto.request.RegisterOrderDto;
+import com.fastcampus.reserve.domain.order.dto.response.OrderInfoDto;
 import com.fastcampus.reserve.domain.order.dto.response.RegisterOrderInfoDto;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +24,7 @@ public class OrderService {
 
     private final RedisService redisService;
     private final OrderCommand orderCommand;
+    private final OrderReader orderReader;
     private final RegisterOrderFactory registerOrderFactory;
 
     public String registerOrder(RegisterOrderDto dto) {
@@ -41,6 +43,11 @@ public class OrderService {
     public RegisterOrderInfoDto findRegisterOrder(String orderToken) {
         var registerOrder = getRegisterOrder(orderToken);
         return RegisterOrderInfoDto.from(orderToken, registerOrder);
+    }
+
+    public OrderInfoDto findOrder(Long orderId) {
+        var order = orderReader.findByIdWithOrderItem(orderId);
+        return OrderInfoDto.from(order);
     }
 
     private RegisterOrder getRegisterOrder(String orderToken) {

--- a/src/main/java/com/fastcampus/reserve/domain/order/dto/response/OrderInfoDto.java
+++ b/src/main/java/com/fastcampus/reserve/domain/order/dto/response/OrderInfoDto.java
@@ -1,0 +1,41 @@
+package com.fastcampus.reserve.domain.order.dto.response;
+
+import com.fastcampus.reserve.domain.order.Order;
+import com.fastcampus.reserve.domain.order.payment.Payment;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record OrderInfoDto(
+        Long orderId,
+        String reserveName,
+        String reservePhone,
+        String userName,
+        String userPhone,
+        int totalPrice,
+        LocalDate reserveDate,
+        Payment payment,
+        List<OrderItemInfoDto> orderItems
+) {
+
+    public static OrderInfoDto from(Order order) {
+        return OrderInfoDto.builder()
+                .orderId(order.getId())
+                .reserveName(order.getReserveName())
+                .reservePhone(order.getReservePhone())
+                .userName(order.getUserName())
+                .userPhone(order.getUserPhone())
+                .totalPrice(order.calcTotalPrice())
+                .reserveDate(order.getCreatedDate().toLocalDate())
+                .payment(order.getPayment())
+                .orderItems(getOrderItems(order))
+                .build();
+    }
+
+    private static List<OrderItemInfoDto> getOrderItems(Order order) {
+        return order.getOrderItems().stream()
+                .map(OrderItemInfoDto::from)
+                .toList();
+    }
+}

--- a/src/main/java/com/fastcampus/reserve/domain/order/dto/response/OrderItemInfoDto.java
+++ b/src/main/java/com/fastcampus/reserve/domain/order/dto/response/OrderItemInfoDto.java
@@ -1,0 +1,42 @@
+package com.fastcampus.reserve.domain.order.dto.response;
+
+import com.fastcampus.reserve.domain.order.orderitem.OrderItem;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import lombok.Builder;
+
+@Builder
+public record OrderItemInfoDto(
+        Long orderItemId,
+        Long productId,
+        String productName,
+        Long roomId,
+        String roomName,
+        String imageUrl,
+        Integer guestCount,
+        Integer maxGuestCount,
+        Integer baseGuestCount,
+        LocalTime checkInTime,
+        LocalDate checkInDate,
+        LocalTime checkOutTime,
+        LocalDate checkOutDate
+) {
+
+    public static OrderItemInfoDto from(OrderItem orderItem) {
+        return OrderItemInfoDto.builder()
+                .orderItemId(orderItem.getId())
+                .productId(orderItem.getProductId())
+                .productName(orderItem.getProductName())
+                .roomId(orderItem.getRoomId())
+                .roomName(orderItem.getRoomName())
+                .imageUrl(orderItem.getImageUrl())
+                .guestCount(orderItem.getGuestCount())
+                .maxGuestCount(orderItem.getMaxGuestCount())
+                .baseGuestCount(orderItem.getBaseGuestCount())
+                .checkInTime(orderItem.getCheckInTime())
+                .checkInDate(orderItem.getCheckInDate())
+                .checkOutTime(orderItem.getCheckOutTime())
+                .checkOutDate(orderItem.getCheckOutDate())
+                .build();
+    }
+}

--- a/src/main/java/com/fastcampus/reserve/domain/order/dto/response/OrderItemInfoDto.java
+++ b/src/main/java/com/fastcampus/reserve/domain/order/dto/response/OrderItemInfoDto.java
@@ -10,10 +10,8 @@ public record OrderItemInfoDto(
         Long orderItemId,
         Long productId,
         String productName,
-        Long roomId,
         String roomName,
         String imageUrl,
-        Integer guestCount,
         Integer maxGuestCount,
         Integer baseGuestCount,
         LocalTime checkInTime,
@@ -27,10 +25,8 @@ public record OrderItemInfoDto(
                 .orderItemId(orderItem.getId())
                 .productId(orderItem.getProductId())
                 .productName(orderItem.getProductName())
-                .roomId(orderItem.getRoomId())
                 .roomName(orderItem.getRoomName())
                 .imageUrl(orderItem.getImageUrl())
-                .guestCount(orderItem.getGuestCount())
                 .maxGuestCount(orderItem.getMaxGuestCount())
                 .baseGuestCount(orderItem.getBaseGuestCount())
                 .checkInTime(orderItem.getCheckInTime())

--- a/src/main/java/com/fastcampus/reserve/domain/user/User.java
+++ b/src/main/java/com/fastcampus/reserve/domain/user/User.java
@@ -20,7 +20,6 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 
 @Getter
@@ -60,7 +59,7 @@ public class User extends BaseTimeEntity {
 
     @Builder
     private User(String email, String password, String nickname, String phone) {
-        this(email, password, phone, nickname, RoleType.USER);
+        this(email, password, nickname, phone, RoleType.USER);
     }
 
     @Builder

--- a/src/main/java/com/fastcampus/reserve/domain/user/dto/response/UserInfoDto.java
+++ b/src/main/java/com/fastcampus/reserve/domain/user/dto/response/UserInfoDto.java
@@ -3,16 +3,16 @@ package com.fastcampus.reserve.domain.user.dto.response;
 import com.fastcampus.reserve.domain.user.User;
 
 public record UserInfoDto(
-    String email,
-    String nickname,
-    String phone
+        String email,
+        String nickname,
+        String phone
 ) {
 
     public static UserInfoDto from(User user) {
         return new UserInfoDto(
-            user.getEmail(),
-            user.getPhone(),
-            user.getNickname()
+                user.getEmail(),
+                user.getNickname(),
+                user.getPhone()
         );
     }
 }

--- a/src/main/java/com/fastcampus/reserve/infrestructure/order/OrderCommandImpl.java
+++ b/src/main/java/com/fastcampus/reserve/infrestructure/order/OrderCommandImpl.java
@@ -29,6 +29,8 @@ public class OrderCommandImpl implements OrderCommand {
 
         Order order = Order.builder()
                 .userId(registerOrder.userId())
+                .reserveName(registerOrder.name())
+                .reservePhone(registerOrder.phone())
                 .userName(dto.userName())
                 .userPhone(dto.userPhone())
                 .payment(dto.payment())

--- a/src/main/java/com/fastcampus/reserve/infrestructure/order/OrderReaderImpl.java
+++ b/src/main/java/com/fastcampus/reserve/infrestructure/order/OrderReaderImpl.java
@@ -1,0 +1,23 @@
+package com.fastcampus.reserve.infrestructure.order;
+
+import com.fastcampus.reserve.common.exception.CustomException;
+import com.fastcampus.reserve.common.response.ErrorCode;
+import com.fastcampus.reserve.domain.order.Order;
+import com.fastcampus.reserve.domain.order.OrderReader;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OrderReaderImpl implements OrderReader {
+
+    private final OrderRepository orderRepository;
+
+    @Override
+    public Order findByIdWithOrderItem(Long orderId) {
+        return orderRepository.findByIdWithOrderItem(orderId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NO_SUCH_ORDER));
+    }
+}

--- a/src/main/java/com/fastcampus/reserve/infrestructure/order/OrderRepository.java
+++ b/src/main/java/com/fastcampus/reserve/infrestructure/order/OrderRepository.java
@@ -1,8 +1,16 @@
 package com.fastcampus.reserve.infrestructure.order;
 
 import com.fastcampus.reserve.domain.order.Order;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
 
 public interface OrderRepository extends CrudRepository<Order, Long> {
 
+    @Query("SELECT o "
+            + "FROM Order o "
+            + "JOIN FETCH o.orderItems oi "
+            + "WHERE o.id = :id")
+    Optional<Order> findByIdWithOrderItem(@Param("id") Long id);
 }

--- a/src/main/java/com/fastcampus/reserve/interfaces/order/OrderController.java
+++ b/src/main/java/com/fastcampus/reserve/interfaces/order/OrderController.java
@@ -5,6 +5,7 @@ import com.fastcampus.reserve.common.response.CommonResponse;
 import com.fastcampus.reserve.common.security.PrincipalDetails;
 import com.fastcampus.reserve.interfaces.order.dto.request.PaymentRequest;
 import com.fastcampus.reserve.interfaces.order.dto.request.RegisterOrderRequest;
+import com.fastcampus.reserve.interfaces.order.dto.response.OrderInfoResponse;
 import com.fastcampus.reserve.interfaces.order.dto.response.PaymentResponse;
 import com.fastcampus.reserve.interfaces.order.dto.response.RegisterOrderInfoResponse;
 import com.fastcampus.reserve.interfaces.order.dto.response.RegisterOrderResponse;
@@ -13,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -51,6 +53,14 @@ public class OrderController {
             @RequestParam String orderToken
     ) {
         var response = orderFacade.findRegisterOrder(orderToken);
+        return CommonResponse.ok(mapper.of(response));
+    }
+
+    @GetMapping("/history/{id}")
+    public CommonResponse<OrderInfoResponse> getOrder(
+            @PathVariable Long id
+    ) {
+        var response = orderFacade.findOrder(id);
         return CommonResponse.ok(mapper.of(response));
     }
 }

--- a/src/main/java/com/fastcampus/reserve/interfaces/order/OrderDtoMapper.java
+++ b/src/main/java/com/fastcampus/reserve/interfaces/order/OrderDtoMapper.java
@@ -3,11 +3,15 @@ package com.fastcampus.reserve.interfaces.order;
 import com.fastcampus.reserve.domain.order.dto.request.PaymentDto;
 import com.fastcampus.reserve.domain.order.dto.request.RegisterOrderDto;
 import com.fastcampus.reserve.domain.order.dto.request.RegisterOrderItemDto;
+import com.fastcampus.reserve.domain.order.dto.response.OrderInfoDto;
+import com.fastcampus.reserve.domain.order.dto.response.OrderItemInfoDto;
 import com.fastcampus.reserve.domain.order.dto.response.RegisterOrderInfoDto;
 import com.fastcampus.reserve.domain.order.dto.response.RegisterOrderItemInfoDto;
 import com.fastcampus.reserve.interfaces.order.dto.request.PaymentRequest;
 import com.fastcampus.reserve.interfaces.order.dto.request.RegisterOrderItemRequest;
 import com.fastcampus.reserve.interfaces.order.dto.request.RegisterOrderRequest;
+import com.fastcampus.reserve.interfaces.order.dto.response.OrderInfoResponse;
+import com.fastcampus.reserve.interfaces.order.dto.response.OrderItemInfoResponse;
 import com.fastcampus.reserve.interfaces.order.dto.response.PaymentResponse;
 import com.fastcampus.reserve.interfaces.order.dto.response.RegisterOrderInfoResponse;
 import com.fastcampus.reserve.interfaces.order.dto.response.RegisterOrderItemInfoResponse;
@@ -36,4 +40,8 @@ public interface OrderDtoMapper {
     RegisterOrderItemInfoResponse of(RegisterOrderItemInfoDto response);
 
     RegisterOrderInfoResponse of(RegisterOrderInfoDto response);
+
+    OrderItemInfoResponse of(OrderItemInfoDto response);
+
+    OrderInfoResponse of(OrderInfoDto response);
 }

--- a/src/main/java/com/fastcampus/reserve/interfaces/order/dto/response/OrderInfoResponse.java
+++ b/src/main/java/com/fastcampus/reserve/interfaces/order/dto/response/OrderInfoResponse.java
@@ -1,0 +1,19 @@
+package com.fastcampus.reserve.interfaces.order.dto.response;
+
+import com.fastcampus.reserve.domain.order.payment.Payment;
+import java.time.LocalDate;
+import java.util.List;
+
+public record OrderInfoResponse(
+        Long orderId,
+        String reserveName,
+        String reservePhone,
+        String userName,
+        String userPhone,
+        int totalPrice,
+        LocalDate reserveDate,
+        Payment payment,
+        List<OrderItemInfoResponse> orderItems
+) {
+
+}

--- a/src/main/java/com/fastcampus/reserve/interfaces/order/dto/response/OrderItemInfoResponse.java
+++ b/src/main/java/com/fastcampus/reserve/interfaces/order/dto/response/OrderItemInfoResponse.java
@@ -1,0 +1,20 @@
+package com.fastcampus.reserve.interfaces.order.dto.response;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record OrderItemInfoResponse(
+        Long orderItemId,
+        Long productId,
+        String productName,
+        String roomName,
+        String imageUrl,
+        Integer maxGuestCount,
+        Integer baseGuestCount,
+        LocalTime checkInTime,
+        LocalDate checkInDate,
+        LocalTime checkOutTime,
+        LocalDate checkOutDate
+) {
+
+}

--- a/src/test/java/com/fastcampus/reserve/common/CreateUtils.java
+++ b/src/test/java/com/fastcampus/reserve/common/CreateUtils.java
@@ -18,7 +18,7 @@ public final class CreateUtils {
         return User.builder()
                 .email("user@gmail.com")
                 .password("password")
-                .nickname("reserveName")
+                .nickname("nickname")
                 .phone("010-0000-0000")
                 .build();
     }
@@ -26,7 +26,7 @@ public final class CreateUtils {
     public static Order createOrder() {
         return Order.builder()
                 .userId(-1L)
-                .reserveName("reserveName")
+                .reserveName("nickname")
                 .reservePhone("010-0000-0000")
                 .userName("userName")
                 .userPhone("010-0000-0000")
@@ -37,7 +37,7 @@ public final class CreateUtils {
     public static RegisterOrder createRegisterOrder() {
         return RegisterOrder.builder()
                 .userId(-1L)
-                .name("reserveName")
+                .name("nickname")
                 .phone("010-0000-0000")
                 .orderItems(List.of(createOrderItem()))
                 .build();

--- a/src/test/java/com/fastcampus/reserve/common/CreateUtils.java
+++ b/src/test/java/com/fastcampus/reserve/common/CreateUtils.java
@@ -6,8 +6,10 @@ import com.fastcampus.reserve.domain.order.orderitem.OrderItem;
 import com.fastcampus.reserve.domain.order.payment.Payment;
 import com.fastcampus.reserve.domain.user.User;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
+import org.springframework.test.util.ReflectionTestUtils;
 
 public final class CreateUtils {
 
@@ -24,13 +26,20 @@ public final class CreateUtils {
     }
 
     public static Order createOrder() {
-        return Order.builder()
+        Order order = Order.builder()
                 .payment(Payment.CARD)
                 .reserveName("reserveName")
                 .reservePhone("010-0000-0000")
                 .userName("userName")
                 .userPhone("010-0000-0000")
                 .build();
+        order.addOrderItem(createOrderItem());
+        ReflectionTestUtils.setField(
+                order,
+                "createdDate",
+                LocalDateTime.of(2023, 11, 25, 15, 30)
+        );
+        return order;
     }
 
     public static RegisterOrder createRegisterOrder() {
@@ -38,15 +47,15 @@ public final class CreateUtils {
                 .userId(-1L)
                 .name("reserveName")
                 .phone("010-0000-0000")
-                .orderItems(createOrderItems())
+                .orderItems(List.of(createOrderItem()))
                 .build();
     }
 
-    public static List<OrderItem> createOrderItems() {
-        return List.of(OrderItem.builder()
+    public static OrderItem createOrderItem() {
+        return OrderItem.builder()
                 .productId(-1L)
                 .roomId(-1L)
-                .price(139000)
+                .price(99000)
                 .guestCount(2)
                 .baseGuestCount(2)
                 .maxGuestCount(4)
@@ -54,6 +63,6 @@ public final class CreateUtils {
                 .checkInTime(LocalTime.of(15, 0))
                 .checkOutDate(LocalDate.now().plusDays(1))
                 .checkOutTime(LocalTime.of(12, 0))
-                .build());
+                .build();
     }
 }

--- a/src/test/java/com/fastcampus/reserve/common/CreateUtils.java
+++ b/src/test/java/com/fastcampus/reserve/common/CreateUtils.java
@@ -6,10 +6,8 @@ import com.fastcampus.reserve.domain.order.orderitem.OrderItem;
 import com.fastcampus.reserve.domain.order.payment.Payment;
 import com.fastcampus.reserve.domain.user.User;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
-import org.springframework.test.util.ReflectionTestUtils;
 
 public final class CreateUtils {
 
@@ -26,20 +24,14 @@ public final class CreateUtils {
     }
 
     public static Order createOrder() {
-        Order order = Order.builder()
-                .payment(Payment.CARD)
+        return Order.builder()
+                .userId(-1L)
                 .reserveName("reserveName")
                 .reservePhone("010-0000-0000")
                 .userName("userName")
                 .userPhone("010-0000-0000")
+                .payment(Payment.CARD)
                 .build();
-        order.addOrderItem(createOrderItem());
-        ReflectionTestUtils.setField(
-                order,
-                "createdDate",
-                LocalDateTime.of(2023, 11, 25, 15, 30)
-        );
-        return order;
     }
 
     public static RegisterOrder createRegisterOrder() {
@@ -54,9 +46,12 @@ public final class CreateUtils {
     public static OrderItem createOrderItem() {
         return OrderItem.builder()
                 .productId(-1L)
+                .productName("숙박 업소 이름")
                 .roomId(-1L)
-                .price(99000)
+                .roomName("방 이름")
+                .imageUrl("이미지 URL")
                 .guestCount(2)
+                .price(99000)
                 .baseGuestCount(2)
                 .maxGuestCount(4)
                 .checkInDate(LocalDate.now())

--- a/src/test/java/com/fastcampus/reserve/common/CreateUtils.java
+++ b/src/test/java/com/fastcampus/reserve/common/CreateUtils.java
@@ -18,7 +18,7 @@ public final class CreateUtils {
         return User.builder()
                 .email("user@gmail.com")
                 .password("password")
-                .nickname("name")
+                .nickname("reserveName")
                 .phone("010-0000-0000")
                 .build();
     }
@@ -26,6 +26,8 @@ public final class CreateUtils {
     public static Order createOrder() {
         return Order.builder()
                 .payment(Payment.CARD)
+                .reserveName("reserveName")
+                .reservePhone("010-0000-0000")
                 .userName("userName")
                 .userPhone("010-0000-0000")
                 .build();
@@ -34,7 +36,7 @@ public final class CreateUtils {
     public static RegisterOrder createRegisterOrder() {
         return RegisterOrder.builder()
                 .userId(-1L)
-                .name("name")
+                .name("reserveName")
                 .phone("010-0000-0000")
                 .orderItems(createOrderItems())
                 .build();

--- a/src/test/java/com/fastcampus/reserve/config/EmbeddedRedisConfig.java
+++ b/src/test/java/com/fastcampus/reserve/config/EmbeddedRedisConfig.java
@@ -9,10 +9,11 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.util.StringUtils;
 import redis.embedded.RedisServer;
 
-//@Configuration
+@Configuration
 public class EmbeddedRedisConfig {
 
     @Value("${redis.port}")

--- a/src/test/java/com/fastcampus/reserve/config/EmbeddedRedisConfig.java
+++ b/src/test/java/com/fastcampus/reserve/config/EmbeddedRedisConfig.java
@@ -9,11 +9,10 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.util.StringUtils;
 import redis.embedded.RedisServer;
 
-@Configuration
+//@Configuration
 public class EmbeddedRedisConfig {
 
     @Value("${redis.port}")

--- a/src/test/java/com/fastcampus/reserve/domain/order/OrderServiceTest.java
+++ b/src/test/java/com/fastcampus/reserve/domain/order/OrderServiceTest.java
@@ -1,5 +1,6 @@
 package com.fastcampus.reserve.domain.order;
 
+import static com.fastcampus.reserve.common.CreateUtils.createOrder;
 import static com.fastcampus.reserve.common.CreateUtils.createRegisterOrder;
 import static com.fastcampus.reserve.common.CreateUtils.createUser;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -11,6 +12,7 @@ import com.fastcampus.reserve.domain.RedisService;
 import com.fastcampus.reserve.domain.order.dto.request.PaymentDto;
 import com.fastcampus.reserve.domain.order.dto.request.RegisterOrderDto;
 import com.fastcampus.reserve.domain.order.dto.request.RegisterOrderItemDto;
+import com.fastcampus.reserve.domain.order.dto.response.OrderInfoDto;
 import com.fastcampus.reserve.domain.order.dto.response.RegisterOrderInfoDto;
 import com.fastcampus.reserve.domain.order.payment.Payment;
 import java.time.LocalDate;
@@ -38,6 +40,8 @@ class OrderServiceTest {
 
     @Mock
     private OrderCommand orderCommand;
+    @Mock
+    private OrderReader orderReader;
 
     @Test
     @DisplayName("숙소 예약 신청 성공")
@@ -105,6 +109,22 @@ class OrderServiceTest {
 
         // when
         RegisterOrderInfoDto result = orderService.findRegisterOrder(orderToken);
+
+        // then
+        assertThat(result).isNotNull();
+    }
+
+    @Test
+    @DisplayName("주문 내역 상세 조회")
+    void findOrder() {
+        // given
+        Long orderId = -1L;
+
+        when(orderReader.findByIdWithOrderItem(orderId))
+                .thenReturn(createOrder());
+
+        // when
+        OrderInfoDto result = orderService.findOrder(orderId);
 
         // then
         assertThat(result).isNotNull();

--- a/src/test/java/com/fastcampus/reserve/domain/order/OrderServiceTest.java
+++ b/src/test/java/com/fastcampus/reserve/domain/order/OrderServiceTest.java
@@ -1,6 +1,7 @@
 package com.fastcampus.reserve.domain.order;
 
 import static com.fastcampus.reserve.common.CreateUtils.createOrder;
+import static com.fastcampus.reserve.common.CreateUtils.createOrderItem;
 import static com.fastcampus.reserve.common.CreateUtils.createRegisterOrder;
 import static com.fastcampus.reserve.common.CreateUtils.createUser;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -16,6 +17,7 @@ import com.fastcampus.reserve.domain.order.dto.response.OrderInfoDto;
 import com.fastcampus.reserve.domain.order.dto.response.RegisterOrderInfoDto;
 import com.fastcampus.reserve.domain.order.payment.Payment;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
@@ -25,6 +27,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @DisplayName("주문 검증")
 @ExtendWith(MockitoExtension.class)
@@ -120,8 +123,16 @@ class OrderServiceTest {
         // given
         Long orderId = -1L;
 
+        Order order = createOrder();
+        ReflectionTestUtils.setField(
+                order,
+                "createdDate",
+                LocalDateTime.of(2023, 11, 25, 15, 30)
+        );
+        order.addOrderItem(createOrderItem());
+
         when(orderReader.findByIdWithOrderItem(orderId))
-                .thenReturn(createOrder());
+                .thenReturn(order);
 
         // when
         OrderInfoDto result = orderService.findOrder(orderId);

--- a/src/test/java/com/fastcampus/reserve/infrestructure/order/OrderRepositoryTest.java
+++ b/src/test/java/com/fastcampus/reserve/infrestructure/order/OrderRepositoryTest.java
@@ -1,0 +1,48 @@
+package com.fastcampus.reserve.infrestructure.order;
+
+import static com.fastcampus.reserve.common.CreateUtils.createOrder;
+import static com.fastcampus.reserve.common.CreateUtils.createOrderItem;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fastcampus.reserve.domain.order.Order;
+import com.fastcampus.reserve.domain.order.orderitem.OrderItem;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+@DisplayName("주문 DB 검증")
+class OrderRepositoryTest {
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Autowired
+    private OrderRepository orderRepository;
+
+    @Test
+    @DisplayName("주문과 주문 상품 조회")
+    void findByIdWithOrderItem() {
+        // given
+        Order order = createOrder();
+        OrderItem orderItem = createOrderItem();
+        orderItem.registerOrder(order);
+        saveEntity(order);
+
+        // when
+        Order result = orderRepository.findByIdWithOrderItem(order.getId()).orElse(null);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(order.getId());
+        assertThat(result.getOrderItems().size()).isEqualTo(1);
+    }
+
+    private void saveEntity(Object entity) {
+        entityManager.persist(entity);
+        entityManager.flush();
+        entityManager.clear();
+    }
+}

--- a/src/test/java/com/fastcampus/reserve/interfaces/order/OrderControllerTest.java
+++ b/src/test/java/com/fastcampus/reserve/interfaces/order/OrderControllerTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.fastcampus.reserve.common.ApiTest;
 import com.fastcampus.reserve.common.RestAssuredUtils;
+import com.fastcampus.reserve.domain.order.dto.response.OrderItemInfoDto;
 import com.fastcampus.reserve.interfaces.order.dto.request.PaymentRequest;
 import com.fastcampus.reserve.interfaces.order.dto.request.RegisterOrderItemRequest;
 import com.fastcampus.reserve.interfaces.order.dto.request.RegisterOrderRequest;
@@ -43,14 +44,7 @@ class OrderControllerTest extends ApiTest {
     void payment() {
         // given
         String orderToken = getOrderToken();
-
-        PaymentRequest request = new PaymentRequest(
-                orderToken,
-                "userName",
-                "010-0000-0000",
-                99000,
-                CARD
-        );
+        PaymentRequest request = createPaymentRequest(orderToken);
 
         String url = "/v1/orders/payment";
 
@@ -62,7 +56,7 @@ class OrderControllerTest extends ApiTest {
     }
 
     @Test
-    @DisplayName("예약 신청 조회")
+    @DisplayName("예약 신청 조정")
     void getRegisterOrder() {
         // given
         String orderToken = getOrderToken();
@@ -119,6 +113,74 @@ class OrderControllerTest extends ApiTest {
         );
     }
 
+    @Test
+    @DisplayName("주문 내역 상세 조회")
+    void getOrder() {
+        // given
+        Long orderId = getOrderId();
+        String url = "/v1/orders/history/" + orderId;
+
+        // when
+        ExtractableResponse<Response> result = RestAssuredUtils.getWithLogin(url);
+
+        // then
+        JsonPath jsonPath = result.jsonPath();
+        OrderItemInfoDto response = jsonPath.getList(
+                        "data.orderItems",
+                        OrderItemInfoDto.class
+                )
+                .get(0);
+
+        assertAll(
+                () -> assertThat(result.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(jsonPath.getLong("data.orderId"))
+                        .isEqualTo(orderId),
+                () -> assertThat(jsonPath.getString("data.reserveName"))
+                        .isEqualTo("nickname"),
+                () -> assertThat(jsonPath.getString("data.reservePhone"))
+                        .isEqualTo("010-0000-0000"),
+                () -> assertThat(jsonPath.getString("data.userName"))
+                        .isEqualTo("userName"),
+                () -> assertThat(jsonPath.getString("data.userPhone"))
+                        .isEqualTo("010-0000-0000"),
+                () -> assertThat(jsonPath.getInt("data.totalPrice"))
+                        .isEqualTo(99000),
+                () -> assertThat(jsonPath.getString("data.reserveDate"))
+                        .isEqualTo("2023-11-28"),
+                () -> assertThat(jsonPath.getString("data.payment"))
+                        .isEqualTo("CARD"),
+                () -> assertThat(response.orderItemId())
+                        .isEqualTo(1L),
+                () -> assertThat(response.productId())
+                        .isEqualTo(-1L),
+                () -> assertThat(response.productName())
+                        .isEqualTo("name"),
+                () -> assertThat(response.roomName())
+                        .isEqualTo("name"),
+                () -> assertThat(response.imageUrl())
+                        .isEqualTo("https://www.image.co.kr"),
+                () -> assertThat(response.maxGuestCount())
+                        .isEqualTo(4),
+                () -> assertThat(response.baseGuestCount())
+                        .isEqualTo(2),
+                () -> assertThat(response.checkInTime())
+                        .isEqualTo(LocalTime.of(15, 0)),
+                () -> assertThat(response.checkInDate())
+                        .isEqualTo(LocalDate.of(2023, 11, 28)),
+                () -> assertThat(response.checkOutTime())
+                        .isEqualTo(LocalTime.of(12, 0)),
+                () -> assertThat(response.checkOutDate())
+                        .isEqualTo(LocalDate.of(2023, 11, 29))
+        );
+    }
+
+    private String getOrderToken() {
+        return RestAssuredUtils
+                .postWithLogin("/v1/orders", createRequestOrderRequest())
+                .jsonPath()
+                .getString("data.orderToken");
+    }
+
     private RegisterOrderRequest createRequestOrderRequest() {
         return new RegisterOrderRequest(List.of(createRegisterOrderItemRequest()));
     }
@@ -136,10 +198,22 @@ class OrderControllerTest extends ApiTest {
         );
     }
 
-    private String getOrderToken() {
-        return RestAssuredUtils
-                .postWithLogin("/v1/orders", createRequestOrderRequest())
+    private Long getOrderId() {
+        String orderToken = getOrderToken();
+        PaymentRequest request = createPaymentRequest(orderToken);
+
+        return RestAssuredUtils.postWithLogin("/v1/orders/payment", request)
                 .jsonPath()
-                .getString("data.orderToken");
+                .getLong("data.orderId");
+    }
+
+    private PaymentRequest createPaymentRequest(String orderToken) {
+        return new PaymentRequest(
+                orderToken,
+                "userName",
+                "010-0000-0000",
+                99000,
+                CARD
+        );
     }
 }

--- a/src/test/java/com/fastcampus/reserve/interfaces/order/OrderControllerTest.java
+++ b/src/test/java/com/fastcampus/reserve/interfaces/order/OrderControllerTest.java
@@ -20,9 +20,11 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 
+@DisplayName("주문 통합 테스트")
 class OrderControllerTest extends ApiTest {
 
     @Test
+    @DisplayName("예약 신청")
     void registerOrder() {
         // given
         RegisterOrderRequest request = createRequestOrderRequest();
@@ -60,6 +62,7 @@ class OrderControllerTest extends ApiTest {
     }
 
     @Test
+    @DisplayName("예약 신청 조회")
     void getRegisterOrder() {
         // given
         String orderToken = getOrderToken();

--- a/src/test/java/com/fastcampus/reserve/interfaces/order/OrderControllerTest.java
+++ b/src/test/java/com/fastcampus/reserve/interfaces/order/OrderControllerTest.java
@@ -81,9 +81,9 @@ class OrderControllerTest extends ApiTest {
                 () -> assertThat(jsonPath.getInt("data.totalPrice"))
                         .isEqualTo(99000),
                 () -> assertThat(jsonPath.getString("data.name"))
-                        .isEqualTo("010-0000-0000"),
-                () -> assertThat(jsonPath.getString("data.phone"))
                         .isEqualTo("nickname"),
+                () -> assertThat(jsonPath.getString("data.phone"))
+                        .isEqualTo("010-0000-0000"),
                 () -> assertThat(response.productId())
                         .isEqualTo(-1L),
                 () -> assertThat(response.productName())

--- a/src/test/java/com/fastcampus/reserve/restdocs/order/OrderDocumentationTest.java
+++ b/src/test/java/com/fastcampus/reserve/restdocs/order/OrderDocumentationTest.java
@@ -1,6 +1,7 @@
 package com.fastcampus.reserve.restdocs.order;
 
 import static com.fastcampus.reserve.common.CreateUtils.createOrder;
+import static com.fastcampus.reserve.common.CreateUtils.createOrderItem;
 import static com.fastcampus.reserve.common.CreateUtils.createUser;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -24,8 +25,6 @@ import com.fastcampus.reserve.domain.order.orderitem.OrderItem;
 import com.fastcampus.reserve.domain.user.UserReader;
 import com.fastcampus.reserve.infrestructure.order.OrderRepository;
 import jakarta.servlet.http.Cookie;
-import java.time.LocalDate;
-import java.time.LocalTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -101,16 +100,7 @@ public class OrderDocumentationTest extends ApiDocumentation {
         Order order = createOrder();
         ReflectionTestUtils.setField(order, "id", -1L);
 
-        OrderItem orderItem = OrderItem.builder()
-                .productId(-1L)
-                .roomId(-1L)
-                .checkInDate(LocalDate.now())
-                .checkInTime(LocalTime.of(15, 0))
-                .checkOutDate(LocalDate.now().plusDays(2))
-                .checkOutTime(LocalTime.of(12, 0))
-                .guestCount(4)
-                .price(99000)
-                .build();
+        OrderItem orderItem = createOrderItem();
 
         RegisterOrder registerOrder = RegisterOrder.builder()
                 .userId(-1L)

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -21,7 +21,7 @@ spring:
 
 redis:
   host: localhost
-  port: 6379
+  port: 25865
 
 security:
   jwt:

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -21,7 +21,7 @@ spring:
 
 redis:
   host: localhost
-  port: 25865
+  port: 6379
 
 security:
   jwt:


### PR DESCRIPTION
close #17 

주문 내역 상세 조회 기능입니다.

- Fetch 조인을 통해 Order와 OrderItem을 함께 조회하기 때문에 Repository 테스트 작성했습니다.
- User 생성자 phone과 nickname의 위치 변경했고, 더불어 dto도 정상 위치로 변경하였습니다.