### PR TITLE
Feature/18 주문 내역 조회 기능 구현

### DIFF
--- a/src/main/java/com/fastcampus/reserve/application/ProductFacade.java
+++ b/src/main/java/com/fastcampus/reserve/application/ProductFacade.java
@@ -1,15 +1,10 @@
 package com.fastcampus.reserve.application;
 
 
-import com.fastcampus.reserve.domain.dto.request.ProductListOptionDto;
-import com.fastcampus.reserve.domain.dto.response.ProductDto;
-import com.fastcampus.reserve.domain.product.Product;
+import com.fastcampus.reserve.domain.product.dto.request.ProductListOptionDto;
+import com.fastcampus.reserve.domain.product.dto.response.ProductDto;
 import com.fastcampus.reserve.domain.product.ProductService;
-import com.fastcampus.reserve.interfaces.product.ProductDtoMapper;
-import com.fastcampus.reserve.interfaces.product.dto.response.ProductResponse;
-import java.time.LocalDate;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/fastcampus/reserve/application/order/OrderFacade.java
+++ b/src/main/java/com/fastcampus/reserve/application/order/OrderFacade.java
@@ -3,10 +3,13 @@ package com.fastcampus.reserve.application.order;
 import com.fastcampus.reserve.domain.order.OrderService;
 import com.fastcampus.reserve.domain.order.dto.request.PaymentDto;
 import com.fastcampus.reserve.domain.order.dto.request.RegisterOrderDto;
+import com.fastcampus.reserve.domain.order.dto.response.OrderHistoriesDto;
 import com.fastcampus.reserve.domain.order.dto.response.OrderInfoDto;
 import com.fastcampus.reserve.domain.order.dto.response.RegisterOrderInfoDto;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -26,6 +29,10 @@ public class OrderFacade {
 
     public RegisterOrderInfoDto findRegisterOrder(String orderToken) {
         return orderService.findRegisterOrder(orderToken);
+    }
+
+    public List<OrderHistoriesDto> findOrderHistories(Pageable pageable) {
+        return orderService.findOrderHistories(pageable);
     }
 
     public OrderInfoDto findOrder(Long orderId) {

--- a/src/main/java/com/fastcampus/reserve/application/order/OrderFacade.java
+++ b/src/main/java/com/fastcampus/reserve/application/order/OrderFacade.java
@@ -6,7 +6,6 @@ import com.fastcampus.reserve.domain.order.dto.request.RegisterOrderDto;
 import com.fastcampus.reserve.domain.order.dto.response.OrderHistoriesDto;
 import com.fastcampus.reserve.domain.order.dto.response.OrderInfoDto;
 import com.fastcampus.reserve.domain.order.dto.response.RegisterOrderInfoDto;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
@@ -31,7 +30,7 @@ public class OrderFacade {
         return orderService.findRegisterOrder(orderToken);
     }
 
-    public List<OrderHistoriesDto> findOrderHistories(Pageable pageable) {
+    public OrderHistoriesDto findOrderHistories(Pageable pageable) {
         return orderService.findOrderHistories(pageable);
     }
 

--- a/src/main/java/com/fastcampus/reserve/domain/order/OrderReader.java
+++ b/src/main/java/com/fastcampus/reserve/domain/order/OrderReader.java
@@ -5,7 +5,7 @@ import org.springframework.data.domain.Pageable;
 
 public interface OrderReader {
 
-    Page<Order> findAll(Pageable pageable);
+    Page<Order> findAllWithOrderItem(Pageable pageable);
 
     Order findByIdWithOrderItem(Long orderId);
 }

--- a/src/main/java/com/fastcampus/reserve/domain/order/OrderReader.java
+++ b/src/main/java/com/fastcampus/reserve/domain/order/OrderReader.java
@@ -1,6 +1,11 @@
 package com.fastcampus.reserve.domain.order;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 public interface OrderReader {
+
+    Page<Order> findAll(Pageable pageable);
 
     Order findByIdWithOrderItem(Long orderId);
 }

--- a/src/main/java/com/fastcampus/reserve/domain/order/OrderService.java
+++ b/src/main/java/com/fastcampus/reserve/domain/order/OrderService.java
@@ -6,11 +6,14 @@ import com.fastcampus.reserve.common.exception.CustomException;
 import com.fastcampus.reserve.domain.RedisService;
 import com.fastcampus.reserve.domain.order.dto.request.PaymentDto;
 import com.fastcampus.reserve.domain.order.dto.request.RegisterOrderDto;
+import com.fastcampus.reserve.domain.order.dto.response.OrderHistoriesDto;
 import com.fastcampus.reserve.domain.order.dto.response.OrderInfoDto;
 import com.fastcampus.reserve.domain.order.dto.response.RegisterOrderInfoDto;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -43,6 +46,13 @@ public class OrderService {
     public RegisterOrderInfoDto findRegisterOrder(String orderToken) {
         var registerOrder = getRegisterOrder(orderToken);
         return RegisterOrderInfoDto.from(orderToken, registerOrder);
+    }
+
+    public List<OrderHistoriesDto> findOrderHistories(Pageable pageable) {
+        var orders = orderReader.findAll(pageable);
+        return orders.stream()
+                .map(OrderHistoriesDto::from)
+                .toList();
     }
 
     public OrderInfoDto findOrder(Long orderId) {

--- a/src/main/java/com/fastcampus/reserve/domain/order/OrderService.java
+++ b/src/main/java/com/fastcampus/reserve/domain/order/OrderService.java
@@ -9,7 +9,6 @@ import com.fastcampus.reserve.domain.order.dto.request.RegisterOrderDto;
 import com.fastcampus.reserve.domain.order.dto.response.OrderHistoriesDto;
 import com.fastcampus.reserve.domain.order.dto.response.OrderInfoDto;
 import com.fastcampus.reserve.domain.order.dto.response.RegisterOrderInfoDto;
-import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -48,11 +47,9 @@ public class OrderService {
         return RegisterOrderInfoDto.from(orderToken, registerOrder);
     }
 
-    public List<OrderHistoriesDto> findOrderHistories(Pageable pageable) {
+    public OrderHistoriesDto findOrderHistories(Pageable pageable) {
         var orders = orderReader.findAllWithOrderItem(pageable);
-        return orders.stream()
-                .map(OrderHistoriesDto::from)
-                .toList();
+        return OrderHistoriesDto.from(orders);
     }
 
     public OrderInfoDto findOrder(Long orderId) {

--- a/src/main/java/com/fastcampus/reserve/domain/order/OrderService.java
+++ b/src/main/java/com/fastcampus/reserve/domain/order/OrderService.java
@@ -49,7 +49,7 @@ public class OrderService {
     }
 
     public List<OrderHistoriesDto> findOrderHistories(Pageable pageable) {
-        var orders = orderReader.findAll(pageable);
+        var orders = orderReader.findAllWithOrderItem(pageable);
         return orders.stream()
                 .map(OrderHistoriesDto::from)
                 .toList();

--- a/src/main/java/com/fastcampus/reserve/domain/order/dto/response/OrderHistoriesDto.java
+++ b/src/main/java/com/fastcampus/reserve/domain/order/dto/response/OrderHistoriesDto.java
@@ -1,29 +1,35 @@
 package com.fastcampus.reserve.domain.order.dto.response;
 
 import com.fastcampus.reserve.domain.order.Order;
-import com.fastcampus.reserve.domain.order.orderitem.OrderItem;
-import java.time.LocalDate;
 import java.util.List;
 import lombok.Builder;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 @Builder
 public record OrderHistoriesDto(
-        Long orderId,
-        LocalDate reserveDate,
-        List<OrderItemInfoDto> orderItems
+        int size,
+        int pageNumber,
+        int totalPages,
+        long totalElements,
+        List<OrderHistoryDto> orderHistories
 ) {
 
-    public static OrderHistoriesDto from(Order order) {
+    public static OrderHistoriesDto from(Page<Order> orders) {
+        Pageable pageable = orders.getPageable();
+
         return OrderHistoriesDto.builder()
-                .orderId(order.getId())
-                .reserveDate(order.getCreatedDate().toLocalDate())
-                .orderItems(getOrderItems(order.getOrderItems()))
+                .size(pageable.getPageSize())
+                .pageNumber(pageable.getPageNumber())
+                .totalPages(orders.getTotalPages())
+                .totalElements(orders.getTotalElements())
+                .orderHistories(getOrderHistories(orders.getContent()))
                 .build();
     }
 
-    private static List<OrderItemInfoDto> getOrderItems(List<OrderItem> order) {
-        return order.stream()
-                .map(OrderItemInfoDto::from)
+    private static List<OrderHistoryDto> getOrderHistories(List<Order> orders) {
+        return orders.stream()
+                .map(OrderHistoryDto::from)
                 .toList();
     }
 }

--- a/src/main/java/com/fastcampus/reserve/domain/order/dto/response/OrderHistoriesDto.java
+++ b/src/main/java/com/fastcampus/reserve/domain/order/dto/response/OrderHistoriesDto.java
@@ -2,34 +2,21 @@ package com.fastcampus.reserve.domain.order.dto.response;
 
 import com.fastcampus.reserve.domain.order.Order;
 import com.fastcampus.reserve.domain.order.orderitem.OrderItem;
-import com.fastcampus.reserve.domain.order.payment.Payment;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.Builder;
 
 @Builder
-public record OrderInfoDto(
+public record OrderHistoriesDto(
         Long orderId,
-        String reserveName,
-        String reservePhone,
-        String userName,
-        String userPhone,
-        int totalPrice,
         LocalDate reserveDate,
-        Payment payment,
         List<OrderItemInfoDto> orderItems
 ) {
 
-    public static OrderInfoDto from(Order order) {
-        return OrderInfoDto.builder()
+    public static OrderHistoriesDto from(Order order) {
+        return OrderHistoriesDto.builder()
                 .orderId(order.getId())
-                .reserveName(order.getReserveName())
-                .reservePhone(order.getReservePhone())
-                .userName(order.getUserName())
-                .userPhone(order.getUserPhone())
-                .totalPrice(order.calcTotalPrice())
                 .reserveDate(order.getCreatedDate().toLocalDate())
-                .payment(order.getPayment())
                 .orderItems(getOrderItems(order.getOrderItems()))
                 .build();
     }

--- a/src/main/java/com/fastcampus/reserve/domain/order/dto/response/OrderHistoryDto.java
+++ b/src/main/java/com/fastcampus/reserve/domain/order/dto/response/OrderHistoryDto.java
@@ -1,0 +1,29 @@
+package com.fastcampus.reserve.domain.order.dto.response;
+
+import com.fastcampus.reserve.domain.order.Order;
+import com.fastcampus.reserve.domain.order.orderitem.OrderItem;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record OrderHistoryDto(
+        Long orderId,
+        LocalDate reserveDate,
+        List<OrderItemInfoDto> orderItems
+) {
+
+    public static OrderHistoryDto from(Order order) {
+        return OrderHistoryDto.builder()
+                .orderId(order.getId())
+                .reserveDate(order.getCreatedDate().toLocalDate())
+                .orderItems(getOrderItems(order.getOrderItems()))
+                .build();
+    }
+
+    private static List<OrderItemInfoDto> getOrderItems(List<OrderItem> order) {
+        return order.stream()
+                .map(OrderItemInfoDto::from)
+                .toList();
+    }
+}

--- a/src/main/java/com/fastcampus/reserve/domain/product/ProductReader.java
+++ b/src/main/java/com/fastcampus/reserve/domain/product/ProductReader.java
@@ -1,7 +1,6 @@
 package com.fastcampus.reserve.domain.product;
 
-import com.fastcampus.reserve.domain.dto.request.ProductListOptionDto;
-import java.time.LocalDate;
+import com.fastcampus.reserve.domain.product.dto.request.ProductListOptionDto;
 import java.util.List;
 
 public interface ProductReader {

--- a/src/main/java/com/fastcampus/reserve/domain/product/ProductService.java
+++ b/src/main/java/com/fastcampus/reserve/domain/product/ProductService.java
@@ -1,8 +1,7 @@
 package com.fastcampus.reserve.domain.product;
 
-import com.fastcampus.reserve.domain.dto.request.ProductListOptionDto;
-import com.fastcampus.reserve.domain.dto.response.ProductDto;
-import java.time.LocalDate;
+import com.fastcampus.reserve.domain.product.dto.request.ProductListOptionDto;
+import com.fastcampus.reserve.domain.product.dto.response.ProductDto;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/fastcampus/reserve/domain/product/dto/request/ProductListOptionDto.java
+++ b/src/main/java/com/fastcampus/reserve/domain/product/dto/request/ProductListOptionDto.java
@@ -1,4 +1,4 @@
-package com.fastcampus.reserve.domain.dto.request;
+package com.fastcampus.reserve.domain.product.dto.request;
 
 import java.time.LocalDate;
 

--- a/src/main/java/com/fastcampus/reserve/domain/product/dto/response/ProductDto.java
+++ b/src/main/java/com/fastcampus/reserve/domain/product/dto/response/ProductDto.java
@@ -1,4 +1,4 @@
-package com.fastcampus.reserve.domain.dto.response;
+package com.fastcampus.reserve.domain.product.dto.response;
 
 import com.fastcampus.reserve.domain.product.Product;
 

--- a/src/main/java/com/fastcampus/reserve/infrestructure/order/OrderReaderImpl.java
+++ b/src/main/java/com/fastcampus/reserve/infrestructure/order/OrderReaderImpl.java
@@ -6,6 +6,8 @@ import com.fastcampus.reserve.domain.order.Order;
 import com.fastcampus.reserve.domain.order.OrderReader;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -14,6 +16,11 @@ import org.springframework.stereotype.Component;
 public class OrderReaderImpl implements OrderReader {
 
     private final OrderRepository orderRepository;
+
+    @Override
+    public Page<Order> findAllWithOrderItem(Pageable pageable) {
+        return orderRepository.findAllWithOrderItem(pageable);
+    }
 
     @Override
     public Order findByIdWithOrderItem(Long orderId) {

--- a/src/main/java/com/fastcampus/reserve/infrestructure/order/OrderRepository.java
+++ b/src/main/java/com/fastcampus/reserve/infrestructure/order/OrderRepository.java
@@ -2,11 +2,23 @@ package com.fastcampus.reserve.infrestructure.order;
 
 import com.fastcampus.reserve.domain.order.Order;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
 
 public interface OrderRepository extends CrudRepository<Order, Long> {
+
+    @Query(
+            value = "SELECT o "
+                    + "FROM Order o "
+                    + "JOIN FETCH o.orderItems oi",
+            countQuery =
+                    "SELECT COUNT(o) "
+                    + "FROM Order o"
+    )
+    Page<Order> findAllWithOrderItem(Pageable pageable);
 
     @Query("SELECT o "
             + "FROM Order o "

--- a/src/main/java/com/fastcampus/reserve/infrestructure/product/ProductReaderImpl.java
+++ b/src/main/java/com/fastcampus/reserve/infrestructure/product/ProductReaderImpl.java
@@ -1,10 +1,9 @@
 package com.fastcampus.reserve.infrestructure.product;
 
 
-import com.fastcampus.reserve.domain.dto.request.ProductListOptionDto;
+import com.fastcampus.reserve.domain.product.dto.request.ProductListOptionDto;
 import com.fastcampus.reserve.domain.product.Product;
 import com.fastcampus.reserve.domain.product.ProductReader;
-import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;

--- a/src/main/java/com/fastcampus/reserve/interfaces/order/OrderController.java
+++ b/src/main/java/com/fastcampus/reserve/interfaces/order/OrderController.java
@@ -5,6 +5,7 @@ import com.fastcampus.reserve.common.response.CommonResponse;
 import com.fastcampus.reserve.common.security.PrincipalDetails;
 import com.fastcampus.reserve.interfaces.order.dto.request.PaymentRequest;
 import com.fastcampus.reserve.interfaces.order.dto.request.RegisterOrderRequest;
+import com.fastcampus.reserve.interfaces.order.dto.response.OrderHistoriesResponse;
 import com.fastcampus.reserve.interfaces.order.dto.response.OrderInfoResponse;
 import com.fastcampus.reserve.interfaces.order.dto.response.PaymentResponse;
 import com.fastcampus.reserve.interfaces.order.dto.response.RegisterOrderInfoResponse;
@@ -12,6 +13,8 @@ import com.fastcampus.reserve.interfaces.order.dto.response.RegisterOrderRespons
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -53,6 +56,14 @@ public class OrderController {
             @RequestParam String orderToken
     ) {
         var response = orderFacade.findRegisterOrder(orderToken);
+        return CommonResponse.ok(mapper.of(response));
+    }
+
+    @GetMapping("/history")
+    public CommonResponse<OrderHistoriesResponse> getOrderHistories(
+            @PageableDefault Pageable pageable
+    ) {
+        var response = orderFacade.findOrderHistories(pageable);
         return CommonResponse.ok(mapper.of(response));
     }
 

--- a/src/main/java/com/fastcampus/reserve/interfaces/order/OrderDtoMapper.java
+++ b/src/main/java/com/fastcampus/reserve/interfaces/order/OrderDtoMapper.java
@@ -3,6 +3,7 @@ package com.fastcampus.reserve.interfaces.order;
 import com.fastcampus.reserve.domain.order.dto.request.PaymentDto;
 import com.fastcampus.reserve.domain.order.dto.request.RegisterOrderDto;
 import com.fastcampus.reserve.domain.order.dto.request.RegisterOrderItemDto;
+import com.fastcampus.reserve.domain.order.dto.response.OrderHistoriesDto;
 import com.fastcampus.reserve.domain.order.dto.response.OrderInfoDto;
 import com.fastcampus.reserve.domain.order.dto.response.OrderItemInfoDto;
 import com.fastcampus.reserve.domain.order.dto.response.RegisterOrderInfoDto;
@@ -10,6 +11,7 @@ import com.fastcampus.reserve.domain.order.dto.response.RegisterOrderItemInfoDto
 import com.fastcampus.reserve.interfaces.order.dto.request.PaymentRequest;
 import com.fastcampus.reserve.interfaces.order.dto.request.RegisterOrderItemRequest;
 import com.fastcampus.reserve.interfaces.order.dto.request.RegisterOrderRequest;
+import com.fastcampus.reserve.interfaces.order.dto.response.OrderHistoriesResponse;
 import com.fastcampus.reserve.interfaces.order.dto.response.OrderInfoResponse;
 import com.fastcampus.reserve.interfaces.order.dto.response.OrderItemInfoResponse;
 import com.fastcampus.reserve.interfaces.order.dto.response.PaymentResponse;
@@ -44,4 +46,6 @@ public interface OrderDtoMapper {
     OrderItemInfoResponse of(OrderItemInfoDto response);
 
     OrderInfoResponse of(OrderInfoDto response);
+
+    OrderHistoriesResponse of(OrderHistoriesDto response);
 }

--- a/src/main/java/com/fastcampus/reserve/interfaces/order/dto/response/OrderHistoriesResponse.java
+++ b/src/main/java/com/fastcampus/reserve/interfaces/order/dto/response/OrderHistoriesResponse.java
@@ -1,0 +1,13 @@
+package com.fastcampus.reserve.interfaces.order.dto.response;
+
+import java.util.List;
+
+public record OrderHistoriesResponse(
+        int size,
+        int pageNumber,
+        int totalPages,
+        long totalElements,
+        List<OrderHistoryResponse> orderHistories
+) {
+
+}

--- a/src/main/java/com/fastcampus/reserve/interfaces/order/dto/response/OrderHistoryResponse.java
+++ b/src/main/java/com/fastcampus/reserve/interfaces/order/dto/response/OrderHistoryResponse.java
@@ -1,0 +1,12 @@
+package com.fastcampus.reserve.interfaces.order.dto.response;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record OrderHistoryResponse(
+        Long orderId,
+        LocalDate reserveDate,
+        List<OrderItemInfoResponse> orderItems
+) {
+
+}

--- a/src/main/java/com/fastcampus/reserve/interfaces/product/ProductApiController.java
+++ b/src/main/java/com/fastcampus/reserve/interfaces/product/ProductApiController.java
@@ -2,7 +2,7 @@ package com.fastcampus.reserve.interfaces.product;
 
 import com.fastcampus.reserve.application.ProductFacade;
 import com.fastcampus.reserve.common.response.CommonResponse;
-import com.fastcampus.reserve.domain.dto.request.ProductListOptionDto;
+import com.fastcampus.reserve.domain.product.dto.request.ProductListOptionDto;
 import com.fastcampus.reserve.interfaces.product.dto.response.ProductResponse;
 import java.time.LocalDate;
 import java.util.List;

--- a/src/main/java/com/fastcampus/reserve/interfaces/product/ProductDtoMapper.java
+++ b/src/main/java/com/fastcampus/reserve/interfaces/product/ProductDtoMapper.java
@@ -1,15 +1,11 @@
 package com.fastcampus.reserve.interfaces.product;
 
-import com.fastcampus.reserve.domain.dto.response.ProductDto;
-import com.fastcampus.reserve.domain.product.Product;
-import com.fastcampus.reserve.domain.product.ProductImage;
+import com.fastcampus.reserve.domain.product.dto.response.ProductDto;
 import com.fastcampus.reserve.interfaces.product.dto.response.ProductResponse;
 import java.util.ArrayList;
 import java.util.List;
 import org.mapstruct.InjectionStrategy;
 import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
-import org.mapstruct.Named;
 import org.mapstruct.ReportingPolicy;
 
 @Mapper(

--- a/src/test/java/com/fastcampus/reserve/domain/order/OrderServiceTest.java
+++ b/src/test/java/com/fastcampus/reserve/domain/order/OrderServiceTest.java
@@ -138,10 +138,10 @@ class OrderServiceTest {
                 .toList();
 
         when(orderReader.findAllWithOrderItem(pageable))
-                .thenReturn(new PageImpl<>(orderHistories));
+                .thenReturn(new PageImpl<>(orderHistories, pageable, 10));
 
         // when
-        List<OrderHistoriesDto> result = orderService.findOrderHistories(pageable);
+        OrderHistoriesDto result = orderService.findOrderHistories(pageable);
 
         // then
         assertThat(result.size()).isEqualTo(10);

--- a/src/test/java/com/fastcampus/reserve/domain/order/OrderServiceTest.java
+++ b/src/test/java/com/fastcampus/reserve/domain/order/OrderServiceTest.java
@@ -13,20 +13,25 @@ import com.fastcampus.reserve.domain.RedisService;
 import com.fastcampus.reserve.domain.order.dto.request.PaymentDto;
 import com.fastcampus.reserve.domain.order.dto.request.RegisterOrderDto;
 import com.fastcampus.reserve.domain.order.dto.request.RegisterOrderItemDto;
+import com.fastcampus.reserve.domain.order.dto.response.OrderHistoriesDto;
 import com.fastcampus.reserve.domain.order.dto.response.OrderInfoDto;
 import com.fastcampus.reserve.domain.order.dto.response.RegisterOrderInfoDto;
+import com.fastcampus.reserve.domain.order.orderitem.OrderItem;
 import com.fastcampus.reserve.domain.order.payment.Payment;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.LongStream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @DisplayName("주문 검증")
@@ -118,17 +123,37 @@ class OrderServiceTest {
     }
 
     @Test
+    @DisplayName("주문 내역 조회")
+    void findOrderHistories() {
+        // given
+        PageRequest pageable = PageRequest.of(0, 10);
+        List<Order> orderHistories = LongStream.range(0, 10)
+                .mapToObj(i -> {
+                    Order order = getOrder(i);
+                    OrderItem orderItem = createOrderItem();
+                    ReflectionTestUtils.setField(orderItem, "id", i);
+                    orderItem.registerOrder(order);
+                    return order;
+                })
+                .toList();
+
+        when(orderReader.findAll(pageable))
+                .thenReturn(new PageImpl<>(orderHistories));
+
+        // when
+        List<OrderHistoriesDto> result = orderService.findOrderHistories(pageable);
+
+        // then
+        assertThat(result.size()).isEqualTo(10);
+    }
+
+    @Test
     @DisplayName("주문 내역 상세 조회")
     void findOrder() {
         // given
         Long orderId = -1L;
 
-        Order order = createOrder();
-        ReflectionTestUtils.setField(
-                order,
-                "createdDate",
-                LocalDateTime.of(2023, 11, 25, 15, 30)
-        );
+        Order order = getOrder(orderId);
         order.addOrderItem(createOrderItem());
 
         when(orderReader.findByIdWithOrderItem(orderId))
@@ -139,5 +164,16 @@ class OrderServiceTest {
 
         // then
         assertThat(result).isNotNull();
+    }
+
+    private Order getOrder(long i) {
+        Order order = createOrder();
+        ReflectionTestUtils.setField(order, "id", i);
+        ReflectionTestUtils.setField(
+                order,
+                "createdDate",
+                LocalDateTime.of(2023, 11, 25, 15, 30)
+        );
+        return order;
     }
 }

--- a/src/test/java/com/fastcampus/reserve/domain/order/OrderServiceTest.java
+++ b/src/test/java/com/fastcampus/reserve/domain/order/OrderServiceTest.java
@@ -137,7 +137,7 @@ class OrderServiceTest {
                 })
                 .toList();
 
-        when(orderReader.findAll(pageable))
+        when(orderReader.findAllWithOrderItem(pageable))
                 .thenReturn(new PageImpl<>(orderHistories));
 
         // when

--- a/src/test/java/com/fastcampus/reserve/infrestructure/order/OrderRepositoryTest.java
+++ b/src/test/java/com/fastcampus/reserve/infrestructure/order/OrderRepositoryTest.java
@@ -7,10 +7,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fastcampus.reserve.domain.order.Order;
 import com.fastcampus.reserve.domain.order.orderitem.OrderItem;
 import jakarta.persistence.EntityManager;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 
 @DataJpaTest
 @DisplayName("주문 DB 검증")
@@ -23,13 +26,36 @@ class OrderRepositoryTest {
     private OrderRepository orderRepository;
 
     @Test
+    @DisplayName("주문과 주문 상품 페이징 조회")
+    void findAllWithOrderItem() {
+        // given
+        IntStream.range(0, 10)
+                .forEach(i -> {
+                    if (i % 2 == 0) {
+                        saveOrder();
+                        return;
+                    }
+                    Order order = createOrder();
+                    addOrderItem(order);
+                    addOrderItem(order);
+                    saveEntity(order);
+                });
+
+        PageRequest pageable = PageRequest.of(0, 10);
+
+        // when
+        Page<Order> result = orderRepository.findAllWithOrderItem(pageable);
+
+        // then
+        assertThat(result.getSize()).isEqualTo(10);
+
+    }
+
+    @Test
     @DisplayName("주문과 주문 상품 조회")
     void findByIdWithOrderItem() {
         // given
-        Order order = createOrder();
-        OrderItem orderItem = createOrderItem();
-        orderItem.registerOrder(order);
-        saveEntity(order);
+        Order order = saveOrder();
 
         // when
         Order result = orderRepository.findByIdWithOrderItem(order.getId()).orElse(null);
@@ -38,6 +64,18 @@ class OrderRepositoryTest {
         assertThat(result).isNotNull();
         assertThat(result.getId()).isEqualTo(order.getId());
         assertThat(result.getOrderItems().size()).isEqualTo(1);
+    }
+
+    private Order saveOrder() {
+        Order order = createOrder();
+        addOrderItem(order);
+        saveEntity(order);
+        return order;
+    }
+
+    private void addOrderItem(Order order) {
+        OrderItem orderItem = createOrderItem();
+        orderItem.registerOrder(order);
     }
 
     private void saveEntity(Object entity) {

--- a/src/test/java/com/fastcampus/reserve/interfaces/order/OrderControllerTest.java
+++ b/src/test/java/com/fastcampus/reserve/interfaces/order/OrderControllerTest.java
@@ -56,7 +56,7 @@ class OrderControllerTest extends ApiTest {
     }
 
     @Test
-    @DisplayName("예약 신청 조정")
+    @DisplayName("예약 신청 조회")
     void getRegisterOrder() {
         // given
         String orderToken = getOrderToken();

--- a/src/test/java/com/fastcampus/reserve/interfaces/order/OrderControllerTest.java
+++ b/src/test/java/com/fastcampus/reserve/interfaces/order/OrderControllerTest.java
@@ -146,7 +146,7 @@ class OrderControllerTest extends ApiTest {
                 () -> assertThat(jsonPath.getInt("data.totalPrice"))
                         .isEqualTo(99000),
                 () -> assertThat(jsonPath.getString("data.reserveDate"))
-                        .isEqualTo("2023-11-28"),
+                        .isEqualTo(LocalDate.now().toString()),
                 () -> assertThat(jsonPath.getString("data.payment"))
                         .isEqualTo("CARD"),
                 () -> assertThat(response.orderItemId())
@@ -189,9 +189,9 @@ class OrderControllerTest extends ApiTest {
         return new RegisterOrderItemRequest(
                 -1L,
                 -1L,
-                LocalDate.now(),
+                LocalDate.of(2023, 11,28),
                 LocalTime.of(15, 0),
-                LocalDate.now().plusDays(1),
+                LocalDate.of(2023, 11, 29),
                 LocalTime.of(12, 0),
                 4,
                 99000

--- a/src/test/java/com/fastcampus/reserve/interfaces/order/OrderControllerTest.java
+++ b/src/test/java/com/fastcampus/reserve/interfaces/order/OrderControllerTest.java
@@ -10,6 +10,7 @@ import com.fastcampus.reserve.domain.order.dto.response.OrderItemInfoDto;
 import com.fastcampus.reserve.interfaces.order.dto.request.PaymentRequest;
 import com.fastcampus.reserve.interfaces.order.dto.request.RegisterOrderItemRequest;
 import com.fastcampus.reserve.interfaces.order.dto.request.RegisterOrderRequest;
+import com.fastcampus.reserve.interfaces.order.dto.response.OrderHistoriesResponse;
 import com.fastcampus.reserve.interfaces.order.dto.response.RegisterOrderItemInfoResponse;
 import io.restassured.path.json.JsonPath;
 import io.restassured.response.ExtractableResponse;
@@ -17,6 +18,7 @@ import io.restassured.response.Response;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
@@ -110,6 +112,34 @@ class OrderControllerTest extends ApiTest {
                         .isEqualTo(LocalTime.of(12, 0)),
                 () -> assertThat(response.checkOutDate())
                         .isEqualTo(LocalDate.of(2023, 11, 29))
+        );
+    }
+
+    @Test
+    @DisplayName("주문 내역 조회")
+    void getOrderHistories() {
+        // given
+        IntStream.range(0, 3)
+                        .forEach(i -> getOrderId());
+        String url = "/v1/orders/history";
+
+        // when
+        ExtractableResponse<Response> result = RestAssuredUtils.getWithLogin(url);
+
+        // then
+        JsonPath jsonPath = result.jsonPath();
+        OrderHistoriesResponse response = jsonPath.getObject(
+                "data",
+                OrderHistoriesResponse.class
+        );
+
+
+        assertAll(
+                () -> assertThat(result.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(response.size()).isEqualTo(10),
+                () -> assertThat(response.pageNumber()).isEqualTo(0),
+                () -> assertThat(response.totalPages()).isEqualTo(1),
+                () -> assertThat(response.totalElements()).isEqualTo(3)
         );
     }
 

--- a/src/test/java/com/fastcampus/reserve/interfaces/product/ProductApiControllerTest.java
+++ b/src/test/java/com/fastcampus/reserve/interfaces/product/ProductApiControllerTest.java
@@ -7,8 +7,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fastcampus.reserve.application.ProductFacade;
-import com.fastcampus.reserve.domain.dto.response.ProductDto;
-import com.fastcampus.reserve.interfaces.product.dto.response.ProductResponse;
+import com.fastcampus.reserve.domain.product.dto.response.ProductDto;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/fastcampus/reserve/restdocs/order/mock/FakeProductReader.java
+++ b/src/test/java/com/fastcampus/reserve/restdocs/order/mock/FakeProductReader.java
@@ -1,10 +1,9 @@
 package com.fastcampus.reserve.restdocs.order.mock;
 
-import com.fastcampus.reserve.domain.dto.request.ProductListOptionDto;
+import com.fastcampus.reserve.domain.product.dto.request.ProductListOptionDto;
 import com.fastcampus.reserve.domain.product.Product;
 import com.fastcampus.reserve.domain.product.ProductImage;
 import com.fastcampus.reserve.domain.product.ProductReader;
-import java.time.LocalDate;
 import java.util.List;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;


### PR DESCRIPTION
close #18 

주문 내역 목록을 조회하는 기능입니다.

- 페이징 처리
- 페이징 정보
  - size: 한 페이지에 보여질 주문 내역 수
  - pageNumber: 현재 페이지
  - totalPages: 모든 페이지 수
  - totalElements: 모든 주문 내역 수
- Product의 dto 패키지를 이동하였습니다.
- 테스트 코드 LocalDateTime.now() 수정하였습니다.
- API 문서화는 별도의 이슈로 등록하겠습니다. 