### PR TITLE
Feature/75 사용자 별 주문 내역 조회 추가

### DIFF
--- a/src/main/java/com/fastcampus/reserve/application/order/OrderFacade.java
+++ b/src/main/java/com/fastcampus/reserve/application/order/OrderFacade.java
@@ -38,8 +38,8 @@ public class OrderFacade {
         return orderService.findRegisterOrder(orderToken);
     }
 
-    public OrderHistoriesDto findOrderHistories(Pageable pageable) {
-        return orderService.findOrderHistories(pageable);
+    public OrderHistoriesDto findOrderHistories(Long userId, Pageable pageable) {
+        return orderService.findOrderHistories(userId, pageable);
     }
 
     public OrderInfoDto findOrder(Long orderId) {

--- a/src/main/java/com/fastcampus/reserve/domain/order/OrderReader.java
+++ b/src/main/java/com/fastcampus/reserve/domain/order/OrderReader.java
@@ -8,7 +8,7 @@ import org.springframework.data.domain.Pageable;
 
 public interface OrderReader {
 
-    Page<Order> findAllWithOrderItem(Pageable pageable);
+    Page<Order> findAllWithOrderItem(Long userId, Pageable pageable);
 
     Order findByIdWithOrderItem(Long orderId);
 

--- a/src/main/java/com/fastcampus/reserve/domain/order/OrderService.java
+++ b/src/main/java/com/fastcampus/reserve/domain/order/OrderService.java
@@ -66,8 +66,8 @@ public class OrderService {
         return RegisterOrderInfoDto.from(orderToken, registerOrder);
     }
 
-    public OrderHistoriesDto findOrderHistories(Pageable pageable) {
-        var orders = orderReader.findAllWithOrderItem(pageable);
+    public OrderHistoriesDto findOrderHistories(Long userId, Pageable pageable) {
+        var orders = orderReader.findAllWithOrderItem(userId, pageable);
         return OrderHistoriesDto.from(orders);
     }
 

--- a/src/main/java/com/fastcampus/reserve/infrestructure/order/OrderReaderImpl.java
+++ b/src/main/java/com/fastcampus/reserve/infrestructure/order/OrderReaderImpl.java
@@ -24,8 +24,8 @@ public class OrderReaderImpl implements OrderReader {
     private final RoomReader roomReader;
 
     @Override
-    public Page<Order> findAllWithOrderItem(Pageable pageable) {
-        return orderRepository.findAllWithOrderItem(pageable);
+    public Page<Order> findAllWithOrderItem(Long userId, Pageable pageable) {
+        return orderRepository.findAllWithOrderItem(userId, pageable);
     }
 
     @Override

--- a/src/main/java/com/fastcampus/reserve/infrestructure/order/OrderRepository.java
+++ b/src/main/java/com/fastcampus/reserve/infrestructure/order/OrderRepository.java
@@ -13,12 +13,13 @@ public interface OrderRepository extends CrudRepository<Order, Long> {
     @Query(
             value = "SELECT o "
                     + "FROM Order o "
-                    + "JOIN FETCH o.orderItems oi",
-            countQuery =
-                    "SELECT COUNT(o) "
-                    + "FROM Order o"
+                    + "JOIN FETCH o.orderItems oi "
+                    + "WHERE o.userId = :userId",
+            countQuery = "SELECT COUNT(o) "
+                    + "FROM Order o "
+                    + "WHERE o.userId = :userId"
     )
-    Page<Order> findAllWithOrderItem(Pageable pageable);
+    Page<Order> findAllWithOrderItem(@Param("userId") Long userId, Pageable pageable);
 
     @Query("SELECT o "
             + "FROM Order o "

--- a/src/main/java/com/fastcampus/reserve/interfaces/order/OrderController.java
+++ b/src/main/java/com/fastcampus/reserve/interfaces/order/OrderController.java
@@ -59,8 +59,12 @@ public class OrderController {
     }
 
     @GetMapping("/history")
-    public CommonResponse<OrderHistoriesResponse> getOrderHistories(Pageable pageable) {
-        var response = orderFacade.findOrderHistories(pageable);
+    public CommonResponse<OrderHistoriesResponse> getOrderHistories(
+            Pageable pageable,
+            @AuthenticationPrincipal PrincipalDetails principal
+    ) {
+        Long userId = principal.id();
+        var response = orderFacade.findOrderHistories(userId, pageable);
         return CommonResponse.ok(mapper.of(response));
     }
 

--- a/src/test/java/com/fastcampus/reserve/domain/order/OrderServiceTest.java
+++ b/src/test/java/com/fastcampus/reserve/domain/order/OrderServiceTest.java
@@ -139,11 +139,11 @@ class OrderServiceTest {
                 })
                 .toList();
 
-        when(orderReader.findAllWithOrderItem(pageable))
+        when(orderReader.findAllWithOrderItem(-1L, pageable))
                 .thenReturn(new PageImpl<>(orderHistories, pageable, 10));
 
         // when
-        OrderHistoriesDto result = orderService.findOrderHistories(pageable);
+        OrderHistoriesDto result = orderService.findOrderHistories(-1L, pageable);
 
         // then
         assertThat(result.size()).isEqualTo(10);

--- a/src/test/java/com/fastcampus/reserve/infrestructure/order/OrderRepositoryTest.java
+++ b/src/test/java/com/fastcampus/reserve/infrestructure/order/OrderRepositoryTest.java
@@ -44,7 +44,7 @@ class OrderRepositoryTest {
         PageRequest pageable = PageRequest.of(0, 10);
 
         // when
-        Page<Order> result = orderRepository.findAllWithOrderItem(pageable);
+        Page<Order> result = orderRepository.findAllWithOrderItem(-1L, pageable);
 
         // then
         assertThat(result.getSize()).isEqualTo(10);

--- a/src/test/java/com/fastcampus/reserve/interfaces/order/OrderControllerTest.java
+++ b/src/test/java/com/fastcampus/reserve/interfaces/order/OrderControllerTest.java
@@ -6,16 +6,20 @@ import static com.fastcampus.reserve.common.CreateUtils.createRoom;
 import static com.fastcampus.reserve.common.CreateUtils.createRoomImage;
 import static com.fastcampus.reserve.common.RestAssuredUtils.login;
 import static com.fastcampus.reserve.domain.order.payment.Payment.CARD;
+import static com.fastcampus.reserve.domain.order.payment.Payment.CASH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.fastcampus.reserve.common.ApiTest;
 import com.fastcampus.reserve.common.RestAssuredUtils;
+import com.fastcampus.reserve.domain.order.Order;
 import com.fastcampus.reserve.domain.order.dto.response.OrderItemInfoDto;
+import com.fastcampus.reserve.domain.order.orderitem.OrderItem;
 import com.fastcampus.reserve.domain.product.Product;
 import com.fastcampus.reserve.domain.product.ProductImage;
 import com.fastcampus.reserve.domain.product.room.Room;
 import com.fastcampus.reserve.domain.product.room.RoomImage;
+import com.fastcampus.reserve.infrestructure.order.OrderRepository;
 import com.fastcampus.reserve.infrestructure.product.ProductRepository;
 import com.fastcampus.reserve.interfaces.order.dto.request.PaymentRequest;
 import com.fastcampus.reserve.interfaces.order.dto.request.RegisterOrderItemRequest;
@@ -51,6 +55,9 @@ class OrderControllerTest extends ApiTest {
 
     @Autowired
     private ProductRepository productRepository;
+
+    @Autowired
+    private OrderRepository orderRepository;
 
     @BeforeEach
     void setUp() {
@@ -221,6 +228,32 @@ class OrderControllerTest extends ApiTest {
         IntStream.range(0, 2)
                 .forEach(i -> getOrderId());
         String url = "/v1/orders/history";
+
+        Order order = Order.builder()
+                .userId(-99L)
+                .reserveName("reserveName")
+                .reservePhone("010-0000-0000")
+                .userName("userName")
+                .userPhone("010-7289-2911")
+                .payment(CASH)
+                .build();
+        OrderItem orderItem = OrderItem.builder()
+                .productId(-99L)
+                .productName("productName")
+                .roomId(-99L)
+                .roomName("roomName")
+                .imageUrl("imageUrl")
+                .guestCount(2)
+                .price(129000)
+                .baseGuestCount(2)
+                .maxGuestCount(4)
+                .checkInDate(LocalDate.now())
+                .checkInTime("15:30")
+                .checkOutDate(LocalDate.now().plusDays(1))
+                .checkOutTime("11:00")
+                .build();
+        orderItem.registerOrder(order);
+        orderRepository.save(order);
 
         // when
         ExtractableResponse<Response> result = RestAssuredUtils.getWithLogin(url);


### PR DESCRIPTION
close #75 

주문 내역 조회 시, 사용자별 조회 조건이 없어 모든 사용자의 구매 내역이 노출되는 문제 입니다.

- 토큰을 통해 인증 정보에 담긴 UserId 를 파라미터로 전달
- 조회 쿼리 주문 사용자 ID 검색 조건 추가
- 단위 테스트와 통합테스트 수정