### PR TITLE
Feature/85 주문 내역 조회 최근 6개월만 조회되도록 조건 추가

### DIFF
--- a/src/main/java/com/fastcampus/reserve/infrestructure/order/OrderReaderImpl.java
+++ b/src/main/java/com/fastcampus/reserve/infrestructure/order/OrderReaderImpl.java
@@ -7,6 +7,7 @@ import com.fastcampus.reserve.domain.order.OrderReader;
 import com.fastcampus.reserve.domain.order.dto.ReserveDateDto;
 import com.fastcampus.reserve.domain.product.room.RoomReader;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,13 +20,15 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class OrderReaderImpl implements OrderReader {
 
+    private static final int RECENT_MONTH = 6;
     private final OrderRepository orderRepository;
     private final OrderItemRepository orderItemRepository;
     private final RoomReader roomReader;
 
     @Override
     public Page<Order> findAllWithOrderItem(Long userId, Pageable pageable) {
-        return orderRepository.findAllWithOrderItem(userId, pageable);
+        LocalDateTime recentMonthAgo = LocalDateTime.now().minusMonths(RECENT_MONTH);
+        return orderRepository.findAllWithOrderItem(userId, recentMonthAgo, pageable);
     }
 
     @Override

--- a/src/main/java/com/fastcampus/reserve/infrestructure/order/OrderRepository.java
+++ b/src/main/java/com/fastcampus/reserve/infrestructure/order/OrderRepository.java
@@ -1,6 +1,7 @@
 package com.fastcampus.reserve.infrestructure.order;
 
 import com.fastcampus.reserve.domain.order.Order;
+import java.time.LocalDateTime;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -14,12 +15,18 @@ public interface OrderRepository extends CrudRepository<Order, Long> {
             value = "SELECT o "
                     + "FROM Order o "
                     + "JOIN FETCH o.orderItems oi "
-                    + "WHERE o.userId = :userId",
+                    + "WHERE o.userId = :userId "
+                    + "AND o.createdDate >= :recentMonthAgo",
             countQuery = "SELECT COUNT(o) "
                     + "FROM Order o "
-                    + "WHERE o.userId = :userId"
+                    + "WHERE o.userId = :userId "
+                    + "AND o.createdDate >= :recentMonthAgo"
     )
-    Page<Order> findAllWithOrderItem(@Param("userId") Long userId, Pageable pageable);
+    Page<Order> findAllWithOrderItem(
+            @Param("userId") Long userId,
+            @Param("recentMonthAgo") LocalDateTime recentMonthsAgo,
+            Pageable pageable
+    );
 
     @Query("SELECT o "
             + "FROM Order o "

--- a/src/test/java/com/fastcampus/reserve/infrestructure/order/OrderRepositoryTest.java
+++ b/src/test/java/com/fastcampus/reserve/infrestructure/order/OrderRepositoryTest.java
@@ -7,6 +7,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fastcampus.reserve.domain.order.Order;
 import com.fastcampus.reserve.domain.order.orderitem.OrderItem;
 import jakarta.persistence.EntityManager;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -14,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @DataJpaTest
 @DisplayName("주문 DB 검증")
@@ -42,13 +45,17 @@ class OrderRepositoryTest {
                 });
 
         PageRequest pageable = PageRequest.of(0, 10);
+        LocalDateTime recentMonthAgo = LocalDateTime.now().minusMonths(6);
 
         // when
-        Page<Order> result = orderRepository.findAllWithOrderItem(-1L, pageable);
+        Page<Order> result = orderRepository.findAllWithOrderItem(
+                -1L,
+                recentMonthAgo,
+                pageable
+        );
 
         // then
         assertThat(result.getSize()).isEqualTo(10);
-
     }
 
     @Test


### PR DESCRIPTION
주문 내역 조회 시, 최근 6개월의 내역만 조회되도록 수정했습니다.

- LocalDateTime으로 파라미터 추가
- createDate 기준으로 최근 내역 조회